### PR TITLE
remove extra `)`

### DIFF
--- a/HTTP_HEADER_FORMAT.md
+++ b/HTTP_HEADER_FORMAT.md
@@ -14,7 +14,7 @@ balancers, etc.)
 
 ## Field value
 
-`base16(<version>)-<version_format>)`
+`base16(<version>)-<version_format>`
 
 The value will be US-ASCII encoded (which is UTF-8 compliant). Character `-` is
 used as a delimiter between fields.


### PR DESCRIPTION
There was an extra `)` that snuck in there, I hunted it down and caught it. the `)` wasn't hurt in the process it's now released into the wilds and lives a happy life in some Lisp code.