### PR TITLE
Make sure the link will always be right, even after we released this spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Specification for TraceContext propagation format.
 This specification defines formats to pass trace context information across systems. Our goal is to share this with the community so that various tracing and diagnostics products can operate together, and so that services can pass context through them, even if they're not being traced (useful for load balancers, etc.).
 
 ## HTTP Format
-The HTTP format is defined [here](https://github.com/TraceContext/tracecontext-spec/blob/master/HTTP_HEADER_FORMAT.md)
+The HTTP format is defined [here](HTTP_HEADER_FORMAT.md)
 
 ## Binary Format
 TODO: add link here


### PR DESCRIPTION
The link shouldn't target the `master` branch. This will be a problem after released. 

Just catch this when doing translation.