### PR TITLE
Remove some meaningless words about goal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Specification for TraceContext propagation format.
 
 ## Goal
-This specification defines formats to pass trace context information across systems. Our goal is to share this with the community so that various tracing and diagnostics products can operate together, and so that services can pass context through them, even if they're not being traced (useful for load balancers, etc.).
+This specification defines formats to pass trace context information across systems. Our goal is to share this with the community so that various tracing and diagnostics products can operate together.
 
 ## HTTP Format
 The HTTP format is defined [here](HTTP_HEADER_FORMAT.md)


### PR DESCRIPTION
The interop heads are between tracers, right. The sentence in goal makes meaningless to me. Please correct me if I misunderstand this. @adriancole @bogdandrutu 

First of all, TraceContext Spec HTTP HEADS influence anything except the load balance or gateway has security strategy, right? Even they know this spec, they must ask to permit this HEADS with manual config. Security is the highest priority for these system, right.

And for Binary, it is hard to say. It depends on the RPC framework usages. But in general, it is same as HTTP HEADS, if they support something similar, e.g. head, attachment, etc.