### PR TITLE
Correct links to rationale files.

### DIFF
--- a/correlation_context/README.md
+++ b/correlation_context/README.md
@@ -8,7 +8,7 @@ overridden by every service to it's own name.
 
 ## HTTP Format
 The HTTP format is defined [here](HTTP_HEADER_FORMAT.md) and the rationale is defined
-[here](HTTP_HEADER_RATIONALE.md).
+[here](HTTP_HEADER_FORMAT_RATIONALE.md).
 
 ## Binary Format
 TODO: add link here

--- a/trace_context_ext/README.md
+++ b/trace_context_ext/README.md
@@ -5,7 +5,7 @@ Trace context is a set of common and vendor specific properties identifying the 
 `Trace-Context-Ext` header defined separately from `Correlation-Context`. It designed to carry ONLY properties defined by tracing library, not user-defined properties. This way cloud vendors and libraries may guarantee it's value transmission. Transmission of a larger baggage header is not guaranteed.  
 
 ## HTTP Format
-The HTTP header format is defined [here](HTTP_HEADER_FORMAT.md) and the rationale is defined [here](HTTP_HEADER_RATIONALE.md).
+The HTTP header format is defined [here](HTTP_HEADER_FORMAT.md) and the rationale is defined [here](HTTP_HEADER_FORMAT_RATIONALE.md).
 
 ## Binary Format
 TODO: add link here


### PR DESCRIPTION
Correlation-context and trace-context-ext had slightly off filename links. This PR updates those links/ 