### PR TITLE
Fix example of how to parse the trace options

### DIFF
--- a/trace_context/HTTP_HEADER_FORMAT.md
+++ b/trace_context/HTTP_HEADER_FORMAT.md
@@ -113,7 +113,7 @@ mask when interpreting flags.
 
 Here is an example of properly handing trace options:
 ```java
-static final int FLAG_TRACED = 1 << 1; // 00000001
+static final byte FLAG_TRACED = 1; // 00000001
 ...
 boolean traced = (traceOptions & FLAG_TRACED) == FLAG_TRACED
 ```


### PR DESCRIPTION
I could totally be wrong, but I think there is a bug in the example code how to extract the traced flag from the trace options bit field, as `1 << 1` is `00000010` and not `00000001`.