### PR TITLE
Reduce the total number of elements in the tracestate list.

### DIFF
--- a/trace_context/HTTP_HEADER_FORMAT.md
+++ b/trace_context/HTTP_HEADER_FORMAT.md
@@ -167,13 +167,13 @@ This section uses the Augmented Backus-Naur Form (ABNF) notation of [RFC5234](ht
 
 The `OWS` rule defines an optional whitespace. It is used where zero or more whitespace characters might appear. When it is preferred to improve readability - a sender SHOULD generate the optional whitespace as a single space; otherwise, a sender SHOULD NOT generate optional whitespace. See details in corresponding RFC.
 
-The `tracestate` field value is a `list` as defined below. The `list` is a series of `list-members` separated by commas `,`, and a `list-member` is a key/value pair separated by an equals sign `=`. Spaces and horizontal tabs surrounding `list-member`s are ignored. There can be a maximum of 128 `list-member`s in a `list`.
+The `tracestate` field value is a `list` as defined below. The `list` is a series of `list-members` separated by commas `,`, and a `list-member` is a key/value pair separated by an equals sign `=`. Spaces and horizontal tabs surrounding `list-member`s are ignored. There can be a maximum of 32 `list-member`s in a `list`.
 
 A simple example of a `list` with two `list-member`s might look like: `vendorname1=opaqueValue1,vendorname2=opaqueValue2`.
 
 
 ```
-list  = list-member 0*127( OWS "," OWS list-member )
+list  = list-member 0*31( OWS "," OWS list-member )
 list-member = key "=" value
 ```
 

--- a/trace_context/HTTP_HEADER_FORMAT_RATIONALE.md
+++ b/trace_context/HTTP_HEADER_FORMAT_RATIONALE.md
@@ -32,11 +32,23 @@ copy of the `traceparent` format or an opaque string.
 
 ### Size limits
 
+#### Total size limit
+
 Header should be small so providers can satisfy the requirement to pass the value all the time.
 
 512 bytes looks like a reasonable compromise.
 
 TODO: put more thoughts into it
+
+#### Maximum number of elements
+
+Here are some rationals and assumptions:
+- the total size can be calculated 2 * num_elements - 1 (delimiters) + sum(key.size()) + sum(value.size()).
+- we assume that each key will have around 4 elements (e.g. `msft`, `goog`, etc).
+- we assume that each value will have 8 or more characters (e.g. one hex int32).
+- based on the previous two assumptions each key-value pair will have more than 12 characters.
+
+Based on the assumptions and rationals a maximum number of elements of 32 looks like a reasonable compromise.
 
 ### Forcing lower case tracestate names
 


### PR DESCRIPTION
Based on a comment in https://github.com/census-instrumentation/opencensus-java/pull/1300 the total number of elements in the tracestate is too high. Here is the rational:
* 512 (total size) / 128 = 4 (characters per entry).
* Out of this 4 characters 2 are delimiters (= and ,) for each entry (except the first or the last one which has only 1).
* On average an entry has only 2 characters 1 for key and 1 for value. Based on the restriction of the key characters it is impossible to have 128 different keys of length 1.
* Decision to limit the number of entries to 32 is based on the total size, so every entry has on average 14 characters (16 - 2 delimiters).