### PR TITLE
Change traced flag semantics and add recorded flag

### DIFF
--- a/trace_context/HTTP_HEADER_FORMAT.md
+++ b/trace_context/HTTP_HEADER_FORMAT.md
@@ -118,12 +118,15 @@ static final byte FLAG_TRACED = 1; // 00000001
 boolean traced = (traceOptions & FLAG_TRACED) == FLAG_TRACED
 ```
 
-#### Traced Flag (00000001)
+#### Requested Flag (00000001)
 When set, the least significant bit recommends the request should be traced. A caller who
 defers a tracing decision leaves this flag unset.
 
+#### Recorded Flag (00000010)
+When set, the least significant bit documents that the caller may have recorded trace data. A caller who does not record trace data out-of-band leaves this flag unset.
+
 #### Other Flags
-The behavior of other flags, such as (00000010) are undefined.
+The behavior of other flags, such as (00000100) are undefined.
 
 ## Examples of HTTP headers
 
@@ -258,8 +261,9 @@ If the value of `traceparent` field wasn't changed before propagation - `tracest
 Here is the list of allowed mutations:
 
 1. **Update `span-id`**. The value of property `span-id` can be regenerated. This is the most typical mutation and should be considered a default.
-2. **Mark trace for sampling**. The value of `sampled` flag of `trace-options` may be set to `1` if it had value `0` before. `span-id` MUST be regenerated with the `sampled` flag update. This mutation typically happens to mark the importance of a current distributed trace collection.
-3. **Restarting trace**. All properties - `trace-id`, `span-id`, `trace-options` are regenerated. This mutation is used in the services defined as a front gate into secure network and eliminates a potential denial of service attack surface. 
+2. **Request trace capture**. The value of `requested` flag of `trace-options` may be set to `1` if it had value `0` before. `span-id` MUST be regenerated with the `requested` flag update. This mutation typically happens to mark the importance of a current distributed trace collection.
+3. **Update `recorded`**. The value of `recorded` reflects the caller's recording behavior: either the trace data were dropped or they may have been recorded out-of-band. This mutation gives the downstream tracer information about the likelihood its parent's information was recorded.
+4. **Restarting trace**. All properties - `trace-id`, `span-id`, `trace-options` are regenerated. This mutation is used in the services defined as a front gate into secure network and eliminates a potential denial of service attack surface. 
 
 Libraries and platforms MUST NOT make any other mutations to the `traceparent` header.
 

--- a/trace_context/HTTP_HEADER_FORMAT.md
+++ b/trace_context/HTTP_HEADER_FORMAT.md
@@ -118,6 +118,15 @@ static final byte FLAG_TRACED = 1; // 00000001
 boolean traced = (traceOptions & FLAG_TRACED) == FLAG_TRACED
 ```
 
+### Flag behavior
+
+| option       | recorded? | requested? | recording probability | situation                                                          |
+| ------------ | --------  | ---------- | --------------------- | ------------------------------------------------------------------ |
+| 00000000     | no        | false      | low                   | I definitely dropped the data and no one asked for it              |
+| 00000001     | no        | true       | medium                | I definitely dropped the data but someone asked for it             |
+| 00000010     | maybe     | false      | medium                | Maybe I recorded this but no one asked for it yet (maybe deferred) |
+| 00000011     | maybe     | true       | high                  | Maybe I recorded this and someone asked for it                     |
+
 #### Requested Flag (00000001)
 When set, the least significant bit recommends the request should be traced. A caller who
 defers a tracing decision leaves this flag unset.


### PR DESCRIPTION
This PR proposes slightly changing the semantics of the `traced` (also called `sampled`) flag in trace-options, and adding a new flag.

* `traced?` becomes `requested?` and describes whether someone explicitly requested this trace be captured
  * This value is either true or false
  * Once true, this value cannot be downgraded to false
* `recorded` describes whether your parent recorded its tracing information out-of-band
  * This value is either no or maybe
  * This value can change from node to node, it just describes what happened in the last hop

**Background**

There are three use cases I've heard described:

1. As an end-user, I would like to see an end-to-end trace for a particular request. I would like to mark a request for tracing and have that decision propagated and respected by all downstream callers.

_(This is pretty hard to do, since you can't actually force anything downstream to do something. Although also called "force" or "debug" trace, this is more like a "pretty-please" request or hint.)_

2. As an end-user, I would like to see my request traced through multiple implementations/vendors. If a tracer sees that its caller was from a different implementation, it can record that information (trace ID, span ID, and implementor name) so I can go find more information from that implementor. If the upstream caller did not record any additional information (such as timing), it saves me a lookup.

_(Because the hint cannot actually be trusted, i.e. you can't trust that ALL the upstream nodes actually recorded information, just understanding what your parent did is helpful.)_

3. As an end-user, I would like traces to include proxies and load balancers.

_(However, at the time the request hits the proxy or load balancer, you may not know whether or not you should sample. You want to defer the decision.)_

**Proposal**

These use cases can be solved by two different signals: (1) did someone explicitly request that I record this? (2) did my parent propagate its tracing information out of band? These signals can be sent separately as two trace-option flags.

| option | recorded? | requested? | recording probability | situation                                                          |
| ------ | --------  | ---------- | --------------------- | ------------------------------------------------------------------ |
| 00     | no        | false      | low                   | I definitely dropped the data and no one asked for it              |
| 01     | no        | true       | medium                | I definitely dropped the data but someone asked for it             |
| 10     | maybe     | false      | medium                | Maybe I recorded this but no one asked for it yet (maybe deferred) |
| 11     | maybe     | true       | high                  | Maybe I recorded this and someone asked for it                     |

I believe these changes address the concerns of PR #122:

>"sampling states"
>* Undecided - Tracing data collection decision is deferred. (2)
>* Traced - Last hop of request may be recorded. (1)
>* Not traced - Last hop of request is not recorded. (0)

The `recorded?` flag covers 0 and 1 and `requested?` covers 2.

>"force/debug"
>* user requested to trace a request from e.g. Chrome Dev Tools
>* a synthetic test users want to collect end-to-end information

These are covered by `requested?`.

> "deferred"
>* Injecting IDs in the first hop but not collecting a trace and not making a sampling decision
>* A load balancer waiting for a request to return and deciding on whether to keep a trace.

The two deferred cases are covered by `10`.

At @SergeyKanzhelev's suggestion, I added the table to the spec. While it describes all existing flags, those are both specific to "sampling" and may not scale well if we add more unrelated flags in the future. (On a related note, @tedsuo suggested renaming whole trace-options section to sampling-options until the point where we have unrelated flags.)