### PR TITLE
return error code for test results

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+RUN pip install --no-cache-dir aiohttp
+COPY . .
+
+EXPOSE 7777
+
+CMD python ./self_test.py

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,9 +1,0 @@
-FROM python:3
-
-WORKDIR /usr/src/app
-RUN pip install --no-cache-dir aiohttp
-COPY . .
-
-EXPOSE 7777
-
-CMD python ./self_test.py

--- a/test/self_test.py
+++ b/test/self_test.py
@@ -106,4 +106,4 @@ if __name__ == '__main__':
 
 	with DemoServer() as server:
 		os.environ['SERVICE_ENDPOINT'] = 'http://{}:{}/'.format(server.host, server.port)
-		subprocess.call(['python', '-m', 'unittest', '-v'] + sys.argv[1:])
+		sys.exit(subprocess.call(['python', '-m', 'unittest', '-v'] + sys.argv[1:]))

--- a/test/test.py
+++ b/test/test.py
@@ -245,6 +245,11 @@ class TraceContextTest(TestBase):
 		])
 		self.assertNotEqual(traceparent.trace_id.hex(), '12345678901234567890123456789012')
 
+		traceparent, tracestate = self.make_single_request_and_get_tracecontext([
+			['traceparent', '0000-12345678901234567890123456789012-1234567890123456-01'],
+		])
+		self.assertNotEqual(traceparent.trace_id.hex(), '12345678901234567890123456789012')
+
 	def test_traceparent_version_too_short(self):
 		'''
 		harness sends an invalid traceparent with version less than 2 HEXDIG
@@ -831,4 +836,5 @@ Example:
 			suite.addTests(loader.loadTestsFromName(name, module = sys.modules[__name__]))
 	else:
 		suite.addTests(loader.loadTestsFromModule(sys.modules[__name__]))
-	unittest.TextTestRunner(verbosity = 2).run(suite)
+	result = unittest.TextTestRunner(verbosity = 2).run(suite)
+	sys.exit(len(result.errors) + len(result.failures))

--- a/test/tracecontext/test_tracestate.py
+++ b/test/tracecontext/test_tracestate.py
@@ -85,7 +85,7 @@ class TestTracestate(unittest.TestCase):
 		self.assertFalse(Tracestate(state.to_string()[:513]).is_valid())
 
 	def test_method_repr(self):
-		state = Tracestate(Tracestate('foo=1, bar=2, baz=3'))
+		state = Tracestate('foo=1, bar=2, baz=3')
 		self.assertEqual(repr(state), "Tracestate('foo=1,bar=2,baz=3')")
 
 	def test_pop(self):


### PR DESCRIPTION
With this change, the test command will return non-zero error code if there are test failures.