### PR TITLE
fix example - = is not allowed as a tracestate entry value

### DIFF
--- a/trace_context/HTTP_HEADER_FORMAT.md
+++ b/trace_context/HTTP_HEADER_FORMAT.md
@@ -285,13 +285,13 @@ as Base64 encoded opaque values.
 
 Single tracing system (generic format):
 
-```
+``` http
 tracestate: rojo=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
 ```
 
 Multiple tracing systems (with different formatting):
 
-```
+``` http
 tracestate: rojo=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4
 ```
 

--- a/trace_context/HTTP_HEADER_FORMAT.md
+++ b/trace_context/HTTP_HEADER_FORMAT.md
@@ -11,17 +11,19 @@ vendor-specific format.
 
 For example, a client traced in the congo system adds the following headers
 to an outbound http request.
-```
+
+``` http
 traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
-tracestate: congo=BleGNlZWRzIHRohbCBwbGVhc3VyZS4=
+tracestate: congo=BleGNlZWRzIHRohbCBwbGVhc3VyZS4
 ```
 
 If the receiving server is traced in the `rojo` tracing system, it carries
 over the state it received and adds a new entry with the position in
 its trace.
-```
+
+``` http
 traceparent: 00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01
-tracestate: rojo=00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01,congo=BleGNlZWRzIHRohbCBwbGVhc3VyZS4=
+tracestate: rojo=00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01,congo=BleGNlZWRzIHRohbCBwbGVhc3VyZS4
 ```
 
 You'll notice that the `rojo` system reuses the value of `traceparent` in its
@@ -31,9 +33,9 @@ entry in `tracestate`. This means it is a generic tracing system. Otherwise,
 If the receiving server of the above is `congo` again, it continues from its
 last position, overwriting its entry with one representing the new parent.
 
-```
+``` http
 traceparent: 00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01
-tracestate: congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4=,rojo=00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01
+tracestate: congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4,rojo=00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01
 ```
 
 Notice when `congo` wrote its `traceparent` entry, it reuses the last trace ID
@@ -290,7 +292,7 @@ tracestate: rojo=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
 Multiple tracing systems (with different formatting):
 
 ```
-tracestate: rojo=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4=
+tracestate: rojo=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,congo=lZWRzIHRoNhcm5hbCBwbGVhc3VyZS4
 ```
 
 ## Versioning of `tracestate`


### PR DESCRIPTION
More updates for examples are coming - see related issues. This PR fixes the bug