### PR TITLE
Fixes shortName for w3c publication

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
           branch: "master",
         },
         edDraftURI: "https://w3c.github.io/trace-context/",
-        shortName: "distributed-tracing",
+        shortName: "trace-context",
         format: "markdown",
         subjectPrefix: "trace-context",
         wg: "Distributed Tracing Working Group",


### PR DESCRIPTION
Used an improper shortname when it was first published. This fixes it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/pull/206.html" title="Last updated on Nov 27, 2018, 7:20 PM GMT (a292bd6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/206/55b60c6...a292bd6.html" title="Last updated on Nov 27, 2018, 7:20 PM GMT (a292bd6)">Diff</a>