### PR TITLE
Make tracestate limit the responsibility of a platform

### DIFF
--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -392,7 +392,7 @@ tracing system may propagate them as they came, combine into a single
 header or split into multiple headers differently following the RFC
 specification.
 
-Platforms and tracing vendors SHOULD propagate at lease 512 characters
+Platforms and tracing vendors SHOULD propagate at least 512 characters
 of a combined header. This length includes commas required to separate
 list items. But does not include optional white space (`OWA`)
 characters.

--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -404,7 +404,7 @@ propagating `tracestate` SHOULD be weighted against the value of
 monitoring scenarios enabled for the end users.
 
 In situation when `tracestate` needs to be truncated due to size
-limitations platform of tracing vendor MUST truncate whole entries.
+limitations, platform of tracing vendor MUST truncate whole entries.
 Entries larger than `128` characters long SHOULD be removed first. Then
 entries SHOULD be removed starting from the end of `tracestate`. Note,
 other truncation strategies like safe list entries, blocked list entries or

--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -407,7 +407,7 @@ In situation when `tracestate` needs to be truncated due to size
 limitations platform of tracing vendor MUST truncate whole entries.
 Entries larger than `128` characters long SHOULD be removed first. Then
 entries SHOULD be removed starting from the end of `tracestate`. Note,
-other truncation strategies like whitelist entries, blacklist entries or
+other truncation strategies like safe list entries, blocked list entries or
 size-based truncation MAY be used, but highly discouraged. Those
 strategies will decrease interoperability of various tracing vendors.
 

--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -383,23 +383,32 @@ Rather, the entry would be rewritten to only include the most recent position:
 
 **Limits:**
 
+The `tracestate` field contains essential information for request
+correlation. Platforms and tracing systems MUST propagate this field.
 There might be multiple `tracestate` headers in a single request
 according to [RFC7230 section
-3.2.2](https://tools.ietf.org/html/rfc7230#section-3.2.2). Maximum length of a
-combined header MUST be less than 512 characters. This length includes commas
-required to separate list items. But SHOULD NOT include optional white space
-(OWA) characters.
+3.2.2](https://tools.ietf.org/html/rfc7230#section-3.2.2). Platform or
+tracing system may propagate them as they came, combine into a single
+header or split into multiple headers differently following the RFC
+specification.
 
-`tracestate` field contains essential information for request correlation.
-Platforms and tracing systems MUST propagate this header. Compliance with the
-specification will require storing of `tracestate` as part of the request
-payload or associated metadata. Allowing the long field values can make
-compliance to the specification impossible. Thus, the aggressive limit of 512
-characters was chosen.
+Platforms and tracing vendors SHOULD propagate at lease 512 characters
+of a combined header. This length includes commas required to separate
+list items. But does not include optional white space (`OWA`)
+characters.
 
-If the `tracestate` value has more than 512 characters, the tracer CAN decide to
-forward the `tracestate`. When propagating `tracestate` with the excessive
-length - the assumption SHOULD be that the receiver will drop this header.
+There are systems where propagating of 512 characters of `tracestate`
+may be expensive. In this case the maximum size of propagated
+`tracestate` header SHOULD be documented and explained. Cost of
+propagating `tracestate` SHOULD be weighted against the value of
+monitoring scenarios enabled for the end users.
+
+In situation when `tracestate` MUST be truncated due to size limitations
+platform of tracing vendor SHOULD truncate whole list entries starting
+from the end of tracestate. Note, other truncation strategies like
+whitelist entries, blacklist entries or size-based truncation MAY be
+used, but highly discouraged. Those strategies will decrease
+interoperability of various tracing vendors.
 
 ## Examples of HTTP headers
 

--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -403,12 +403,13 @@ may be expensive. In this case the maximum size of propagated
 propagating `tracestate` SHOULD be weighted against the value of
 monitoring scenarios enabled for the end users.
 
-In situation when `tracestate` MUST be truncated due to size limitations
-platform of tracing vendor SHOULD truncate whole list entries starting
-from the end of tracestate. Note, other truncation strategies like
-whitelist entries, blacklist entries or size-based truncation MAY be
-used, but highly discouraged. Those strategies will decrease
-interoperability of various tracing vendors.
+In situation when `tracestate` needs to be truncated due to size
+limitations platform of tracing vendor MUST truncate whole entries.
+Entries larger than `128` characters long SHOULD be removed first. Than
+entries SHOULD be removed starting from the end of `tracestate`. Note,
+other truncation strategies like whitelist entries, blacklist entries or
+size-based truncation MAY be used, but highly discouraged. Those
+strategies will decrease interoperability of various tracing vendors.
 
 ## Examples of HTTP headers
 

--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -405,7 +405,7 @@ monitoring scenarios enabled for the end users.
 
 In situation when `tracestate` needs to be truncated due to size
 limitations platform of tracing vendor MUST truncate whole entries.
-Entries larger than `128` characters long SHOULD be removed first. Than
+Entries larger than `128` characters long SHOULD be removed first. Then
 entries SHOULD be removed starting from the end of `tracestate`. Note,
 other truncation strategies like whitelist entries, blacklist entries or
 size-based truncation MAY be used, but highly discouraged. Those

--- a/spec/21-http_header_format_rationale.md
+++ b/spec/21-http_header_format_rationale.md
@@ -153,7 +153,7 @@ entries. `512` is a nice median length.
 
 Extremely small proposal like `64` wasn't received well by vendors,
 while larger limits was unacceptable/undesirable for cloud vendors as
-COGS of implementing it are quite high.
+costs of implementing it are quite high.
 
 We failed to find a number everybody liked.
 

--- a/spec/21-http_header_format_rationale.md
+++ b/spec/21-http_header_format_rationale.md
@@ -134,7 +134,7 @@ specification is making regarding the size of `tracestate` field will
 only be a recommendation that would improve vendors interoperability and
 cannot be "enforced" in practice.
 
-There solutions to address this problem were discussed:
+Three solutions to address this problem were discussed:
 
 1. Declare the arbitrary max length that HAVE TO be propagated.
 2. Limit based on number of entries, not the size. Declare arbitrary

--- a/spec/21-http_header_format_rationale.md
+++ b/spec/21-http_header_format_rationale.md
@@ -105,12 +105,12 @@ Opaque nature of `tracestate` value raises many questions and biggest
 one is what guarantees we can request from protocol implementors on
 propagating and storing this field.
 
-On one hand - field value should be small so implementors can satisfy
+On the one hand, field value should be small so implementors can satisfy
 the requirement to pass the value all the time. It is especially
 critical for various messaging systems where metadata like `tracestate`
 is not paid for by the customer and provided for free.
 
-On other hand - in order for the field to be useful there should be some
+On the other hand, in order for the field to be useful there should be some
 guarantees that it will in fact be propagated in most of the cases.
 
 Without changing definition of `tracestate` to make it less opaque, any

--- a/spec/21-http_header_format_rationale.md
+++ b/spec/21-http_header_format_rationale.md
@@ -134,13 +134,15 @@ specification is making regarding the size of `tracestate` field will
 only be a recommendation that would improve vendors interoperability and
 cannot be "enforced" in practice.
 
-Possible solutions:
+There solutions to address this problem were discussed:
 
 1. Declare the arbitrary max length that HAVE TO be propagated.
 2. Limit based on number of entries, not the size. Declare arbitrary
    minimum number of entries required for propagation.
 3. Make max length the decision of the implementor. Suggest arbitrary
    max length in specification that implementors SHOULD propagate.
+
+These solutions has the following pros and cons.
 
 #### 1. Declare the arbitrary max length
 
@@ -153,7 +155,7 @@ Extremely small proposal like `64` wasn't received well by vendors,
 while larger limits was unacceptable/undesirable for cloud vendors as
 COGS of implementing it are quite high.
 
-So far we didn't find a number everybody liked.
+We failed to find a number everybody liked.
 
 #### 2. Limit based on number of entries
 
@@ -185,6 +187,10 @@ One of the side effects of this proposal is that it encourages tracing
 vendors to minimize the use of `tracestate` for non-essential scenarios
 to ensure propagation of an essential fields. Which is aligned with the
 spirit of `tracestate`.
+
+One addition to this scenario was made to discourage people using
+`tracestate` values of size larger than `128` long. Specification
+suggests to cut those entries first.
 
 ### Maximum number of elements
 

--- a/spec/21-http_header_format_rationale.md
+++ b/spec/21-http_header_format_rationale.md
@@ -127,6 +127,13 @@ context will provide a relieve valve for people who want to have freedom
 propagating relatively big payload across the components of a
 distributed trace.
 
+Specification allows removing and adding as many `tracestate` entries as
+implementation needs. This freedom is required to satisfy privacy and
+interoperability concerns. Thus all suggestions specification is making
+regarding the size of `tracestate` field will only be a recommendation
+that would improve vendors interoperability and cannot be "enforced" in
+practice.
+
 Possible solutions:
 
 1. Declare the arbitrary max length that HAVE TO be propagated.
@@ -155,17 +162,20 @@ utilizes the full length of a `tracestate` and ultimately blocking the
 interoperability.
 
 Problem with this proposal is that limits proposed for the individual
-entry were still quite high for cloud providers.
+entry (e.g. `128`) were still quite high for cloud providers.
 
 Also even though seemingly this proposal makes interoperability better,
 abuse of using multiple entries by a single vendor is still unavoidable.
+
+Good way to discourage vendors to use long `tracestate` values is to
+suggest to remove those first when limit was reached.
 
 #### 3. Make max length the decision of the implementor
 
 Options above "protected" vendors from implementors who will take
 optional nature of `tracestate` and will not propagate `tracestate`.
 However the reality is that for many platforms even larger `tracestate`
-fields propagation is not a big issue.
+fields propagation is not a concern.
 
 So there was a proposal that the spec will suggest the length limits,
 and define the algorithm of trimming `tracestate`. However the final
@@ -173,7 +183,8 @@ decision of an actual implementation to the platform.
 
 One of the side effects of this proposal is that it encourages tracing
 vendors to minimize the use of `tracestate` for non-essential scenarios
-to ensure propagation of an essential fields.
+to ensure propagation of an essential fields. Which is aligned with the
+spirit of `tracestate`.
 
 ### Maximum number of elements
 

--- a/spec/21-http_header_format_rationale.md
+++ b/spec/21-http_header_format_rationale.md
@@ -101,9 +101,9 @@ providing backward compatibility with older protocols. But `tracestate`
 is not limited to this use and will drive innovations and new scenarios
 going forward.
 
-Opaque nature of `tracestate` value raises many questions and biggest
-one is what guarantees we can request from protocol implementors on
-propagating and storing this field.
+The opaque nature of `tracestate` introduces some tension between
+guarantees to vendors around propagating vendor-specific data with
+traces vs. storage and propagation constraints.
 
 On the one hand, field value should be small so implementors can satisfy
 the requirement to pass the value all the time. It is especially
@@ -127,12 +127,12 @@ context will provide a relieve valve for people who want to have freedom
 propagating relatively big payload across the components of a
 distributed trace.
 
-Specification allows removing and adding as many `tracestate` entries as
-implementation needs. This freedom is required to satisfy privacy and
-interoperability concerns. Thus all suggestions specification is making
-regarding the size of `tracestate` field will only be a recommendation
-that would improve vendors interoperability and cannot be "enforced" in
-practice.
+This specification allows removing and adding as many `tracestate`
+entries as an implementation needs. This freedom is required to satisfy
+privacy and interoperability concerns. Thus all suggestions
+specification is making regarding the size of `tracestate` field will
+only be a recommendation that would improve vendors interoperability and
+cannot be "enforced" in practice.
 
 Possible solutions:
 


### PR DESCRIPTION
Proposed update for the `tracestate` limit. Basically make it a platform responsibility. See #239