### PR TITLE
Mark other protocols section point to the registry

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
         
         <section data-include="spec/20-http_header_format.md" data-include-format='markdown'></section>
 
-        <section data-include="spec/40-other-protocols.md" data-include-format='markdown' class="informative"></section>
+        <section data-include="spec/40-other-protocols.md" data-include-format='markdown'></section>
 
         <section data-include="spec/50-privacy.md" data-include-format='markdown'></section>
         <section data-include="spec/51-security.md" data-include-format='markdown'></section>

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
         
         <section data-include="spec/20-http_header_format.md" data-include-format='markdown'></section>
 
-        <section data-include="spec/40-other-protocols.md" data-include-format='markdown'></section>
+        <section data-include="spec/40-other-protocols.md" data-include-format='markdown' class="informative"></section>
 
         <section data-include="spec/50-privacy.md" data-include-format='markdown'></section>
         <section data-include="spec/51-security.md" data-include-format='markdown'></section>

--- a/spec/40-other-protocols.md
+++ b/spec/40-other-protocols.md
@@ -3,10 +3,11 @@
 Trace Context propagation is crucial to enable distributed tracing scenarios
 for applications spans multiple components. Http is one of the communication
 protocols used for cross components correlation. Extensions of this
-specification define the format of trace context serialization and
+specification as well as specifications defined by external organizations define
+the format of trace context serialization and
 deserialization for other protocols. Note, that those extensions may be at a
 different maturity level than this specification.
 
-- [AMQP](https://w3c.github.io/trace-context/extension-amqp.html).
-- [Binary](https://w3c.github.io/trace-context/extension-binary.html).
-- [Cloud Events extension (external)](https://github.com/cloudevents/spec/blob/master/extensions/distributed-tracing.md).
+Please refer to the [protocols
+registry](https://w3c.github.io/trace-context-protocols-registry/) for the
+details of trace context implementation for other protocols.

--- a/spec/40-other-protocols.md
+++ b/spec/40-other-protocols.md
@@ -9,3 +9,4 @@ different maturity level than this specification.
 
 - [AMQP](https://w3c.github.io/trace-context/extension-amqp.html).
 - [Binary](https://w3c.github.io/trace-context/extension-binary.html).
+- [Cloud Events extension (external)](https://github.com/cloudevents/spec/blob/master/extensions/distributed-tracing.md).


### PR DESCRIPTION
#247 

and added link to CloudEvents extension.

This change will add the note "non-normative" to the spec. Supposedly it means that we will be able to keep updating it without the whole document versioning.

![image](https://user-images.githubusercontent.com/9950081/52807140-8ee5ab80-303f-11e9-84ff-b2418ac31c0f.png)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/pull/249.html" title="Last updated on Feb 15, 2019, 12:45 AM UTC (e702be2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/249/2bd4746...e702be2.html" title="Last updated on Feb 15, 2019, 12:45 AM UTC (e702be2)">Diff</a>