### PR TITLE
traceparent restart should require tracestate cleanup rationale

### DIFF
--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -242,7 +242,7 @@ base16(trace-flags) = 00  // not recorded
 
 ## Versioning of `traceparent`
 
-Implementations is opinionated about future version of the specification. Current
+This specification is opinionated about future version of the trace context. Current
 version of this specification assumes that the future versions of `traceparent`
 header will be additive to the current one.
 

--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -124,7 +124,7 @@ a few telemetry systems call the execution of a client call a span. It is
 represented as an 8-byte array, for example, `00f067aa0ba902b7`. All bytes `0`
 is considered invalid.
 
-Implementation HAVE TO ignore the `traceparent` when the `parent-id` is invalid.
+Implementations HAVE TO ignore the `traceparent` when the `parent-id` is invalid.
 For instance, if it contains non-allowed characters.
 
 ## Trace-flags
@@ -216,7 +216,7 @@ interoperability.
 ### Other Flags
 
 The behavior of other flags, such as (`00000100`) is not defined and reserved
-for future use. Implementation MUST set those to zero.
+for future use. Implementations MUST set those to zero.
 
 ## Examples of HTTP headers
 
@@ -242,11 +242,11 @@ base16(trace-flags) = 00  // not recorded
 
 ## Versioning of `traceparent`
 
-Implementation is opinionated about future version of the specification. Current
+Implementations is opinionated about future version of the specification. Current
 version of this specification assumes that the future versions of `traceparent`
 header will be additive to the current one.
 
-Implementation should follow the following rules when parsing headers with an
+Implementations should follow the following rules when parsing headers with an
 unexpected format:
 
 1. Pass thru services should not analyze version. Pass thru service needs to
@@ -258,16 +258,16 @@ unexpected format:
     1. If the size of header is shorter than 55 characters -implementation
        should not parse header and should restart the trace.
     2. Try parse `trace-id`: from the first dash - next 32 characters.
-       Implementation MUST check 32 characters to be hex. Make sure they are
+       Implementations MUST check 32 characters to be hex. Make sure they are
        followed by dash.
     3. Try parse `parent-id`: from the second dash at 35th position - 16
-       characters. Implementation MUST check 16 characters to be hex. Make sure
+       characters. Implementations MUST check 16 characters to be hex. Make sure
        this is followed by a dash.
     4. Try parse sampling bit of `flags`:  2 characters from third dash.
        Following with either end of string or a dash. If all three values were
-       parsed successfully - implementation should use them. Implementation MUST
+       parsed successfully - implementation should use them. Implementations MUST
        NOT parse or assume anything about any fields unknown for this version.
-       Implementation MUST use these fields to construct the new `traceparent`
+       Implementations MUST use these fields to construct the new `traceparent`
        field according to the highest version of the specification known to the
        implementation (in this specification it is `00`).
 
@@ -418,7 +418,7 @@ tracestate: rojo=00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01,congo=l
 ## Versioning of `tracestate`
 
 Version of `tracestate` is defined by the version prefix of `traceparent`
-header. Implementation needs to attempt parsing of `tracestate` if a higher
+header. Implementations needs to attempt parsing of `tracestate` if a higher
 version is detected to the best of its ability. It is the implementor's decision
 whether to use partially-parsed `tracestate` key-value pairs or not.
 
@@ -453,7 +453,7 @@ Here is the list of allowed mutations:
 4. **Restarting trace**. All properties - `trace-id`, `parent-id`, `trace-flags`
    are regenerated. This mutation is used in the services defined as a front
    gate into secure networks and eliminates a potential denial of service attack
-   surface. Implementation SHOULD clean up `tracestate` collection on
+   surface. Implementations SHOULD clean up `tracestate` collection on
    `traceparent` restart. There are rare cases when the original
    `tracestate` entries must be preserved after restart. Typically, when
    `trace-id` will be reverted back at some point of the trace flow -

--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -454,9 +454,12 @@ Here is the list of allowed mutations:
    are regenerated. This mutation is used in the services defined as a front
    gate into secure networks and eliminates a potential denial of service attack
    surface. Implementation SHOULD clean up `tracestate` collection on
-   `traceparent` restart. In rare cases when original `tracestate` entries must
-   be preserved after restart - it SHOULD be an explicit decision, not a default
-   behavior.
+   `traceparent` restart. There are rare cases when the original
+   `tracestate` entries must be preserved after restart. Typically, when
+   `trace-id` will be reverted back at some point of the trace flow -
+   for instance, when it leaves the secure network. However, it SHOULD
+   be an explicit decision, not a default behavior. As trace vendors may
+   rely on `trace-id` matching `tracestate` values.
 
 Libraries and platforms MUST NOT make any other mutations to the `traceparent`
 header.

--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -453,7 +453,10 @@ Here is the list of allowed mutations:
 4. **Restarting trace**. All properties - `trace-id`, `parent-id`, `trace-flags`
    are regenerated. This mutation is used in the services defined as a front
    gate into secure networks and eliminates a potential denial of service attack
-   surface.
+   surface. Implementation SHOULD clean up `tracestate` collection on
+   `traceparent` restart. In rare cases when original `tracestate` entries must
+   be preserved after restart - it SHOULD be an explicit decision, not a default
+   behavior.
 
 Libraries and platforms MUST NOT make any other mutations to the `traceparent`
 header.

--- a/spec/21-http_header_format_rationale.md
+++ b/spec/21-http_header_format_rationale.md
@@ -154,27 +154,25 @@ One variation is whether original or new header that you cannot recognize is pre
 
 ## Restarting trace
 
-There are two main reasons distributed trace context needs to be restarted -
-logical restart and privacy & security motivated restarts. Privacy & security
-should never be taken lightly. However, trace context is designed to have low
-impact on these aspects and tracing vendors should provide a ways to eliminate
-risks of trusting incoming identifiers without compromising on interoperability
-various systems.
+Developers sometimes feel a need to restart a trace due to security concerns,
+however trace context should not contain information that can compromise your
+application,  and tracing vendors should work through the risks of trusting
+incoming identifiers without compromising on interoperability.
 
-The field `tracestate` carries information that in most cases have strong
-association with the `traceparent`. Specifically, with the `trace-id` field.
-Tracing vendors will assume that association to optimize the size of the
-`tracestate` entry. This is why restarting of a trace context SHOULD clear up
-the `tracestate` list.
+If restarting a trace is unavoidable, you SHOULD clear the `tracestate` list as well.
+The data carried in `tracestate` carries information that often has a strong
+association with the `traceparent`, particularly `trace-id`. Tracing vendors will
+often assume that these values are associated, which is why `tracestate`
+SHOULD be cleared when `traceparent` is changed.
 
-There are scenarios, however, which may require a different behavior.
-For example, if trace was restarted when entered some secure boundaries and
-than restored back when it is leaving those boundaries - keeping original
-`tracestate` entries will increase tracing vendors interoperability.
-Vendor-specific context will be propagated thru the these secure boundaries.
+There are scenarios, however, which may require different behavior.
+For example, if a trace was restarted when entered some secure boundaries and
+than restored back when it is leaving those boundaries - keeping the original
+`tracestate` entries will fully restore the trace back to normal. In this example,
+vendor-specific context will be propagated through these secure boundaries.
 
-Scenarios like one above require careful coding and understanding of what they
-are trying to achieve. It should be considered an exception. Implementations
+Scenarios like the one above require careful coding and understanding of what they
+are trying to achieve, and should be considered an exception. Implementations
 should discourage this type of restarts. For example, implementations may allow
 this scenario only by means of restarting the trace WITH `tracestate` clean up
 and than re-population of `tracestate` can only be implemented as an explicit


### PR DESCRIPTION
Most of the text in this PR is for rationale, not specification. I marked it as editorial as this is what was assumed.

Hopefully this will close #146 and #252
