### PR TITLE
Versioning clarification: Adding newline to indicate that sentence is applied to entire list, not to the last item only

### DIFF
--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -269,11 +269,12 @@ unexpected format:
        this is followed by a dash.
     4. Try parse sampling bit of `flags`:  2 characters from third dash.
        Following with either end of string or a dash. If all three values were
-       parsed successfully - implementation should use them. Implementations
-       MUST NOT parse or assume anything about any fields unknown for this
-       version. Implementations MUST use these fields to construct the new
-       `traceparent` field according to the highest version of the specification
-       known to the implementation (in this specification it is `00`).
+       parsed successfully - implementation should use them.
+
+Implementations MUST NOT parse or assume anything about any fields unknown for
+this version. Implementations MUST use these fields to construct the new
+`traceparent` field according to the highest version of the specification known
+to the implementation (in this specification it is `00`).
 
 ## Tracestate field
 


### PR DESCRIPTION
Just a newline there and formatting. No text change