### PR TITLE
Remove hard line breaks

### DIFF
--- a/spec/01-abstract.md
+++ b/spec/01-abstract.md
@@ -1,6 +1,1 @@
-This specification defines standard HTTP headers and a value format to propagate
-context information that enables distributed tracing scenarios. The
-specification standardizes how context information is sent and modified between
-services. Context information uniquely identifies individual requests in a
-distributed system and also defines a means to add and propagate
-provider-specific context information.
+This specification defines standard HTTP headers and a value format to propagate context information that enables distributed tracing scenarios. The specification standardizes how context information is sent and modified between services. Context information uniquely identifies individual requests in a distributed system and also defines a means to add and propagate provider-specific context information.

--- a/spec/02-sotd.md
+++ b/spec/02-sotd.md
@@ -1,5 +1,1 @@
-This specification is in Candidate Recommendation stage. It was widely viewed
-and discussed. It satisfies Distributed Tracing working group technical
-requirements. There are a few implementations of this specification available.
-We are gathering implementation experience and usage feedback. We recommend the
-wide deployment and use of this recommendation.
+This specification is in Candidate Recommendation stage. It was widely viewed and discussed. It satisfies Distributed Tracing working group technical requirements. There are a few implementations of this specification available. We are gathering implementation experience and usage feedback. We recommend the wide deployment and use of this recommendation.

--- a/spec/10-overview.md
+++ b/spec/10-overview.md
@@ -2,75 +2,37 @@
 
 ## Problem Statement
 
-Distributed tracing is a methodology implemented by tracing tools to follow,
-analyze and debug a transaction across multiple software components. Typically,
-a <a>distributed trace</a> traverses more than one component which requires it
-to be uniquely identifiable across all participating systems. Trace context
-propagation passes along this unique identification.
+Distributed tracing is a methodology implemented by tracing tools to follow, analyze and debug a transaction across multiple software components. Typically, a <a>distributed trace</a> traverses more than one component which requires it to be uniquely identifiable across all participating systems. Trace context propagation passes along this unique identification. Today, trace context propagation is implemented individually by each tracing vendor. In multi-vendor environments, this causes interoperability problems, like:
 
-Today, trace context propagation is implemented individually by each tracing
-vendor. In multi-vendor environments, this causes interoperability problems,
-like:
-
-- Traces that are collected by different tracing vendors cannot be correlated as
-  there is no shared unique identifier.
-- Traces that cross boundaries between different tracing vendors can not be
-  propagated as there is no uniformly agreed set of identification that is
-  forwarded.
+- Traces that are collected by different tracing vendors cannot be correlated as there is no shared unique identifier.
+- Traces that cross boundaries between different tracing vendors can not be propagated as there is no uniformly agreed set of identification that is forwarded.
 - Vendor specific metadata might be dropped by intermediaries.
-- Cloud platform vendors, intermediaries and service providers, cannot guarantee
-  to support trace context propagation as there is no standard to follow.
+- Cloud platform vendors, intermediaries and service providers, cannot guarantee to support trace context propagation as there is no standard to follow.
 
-In the past, these problems did not have a significant impact as most
-applications were monitored by a single tracing vendor and stayed within the
-boundaries of a single platform provider. Today, an increasing number of
-applications are highly distributed and leverage multiple middleware services
-and cloud platforms.
+In the past, these problems did not have a significant impact as most applications were monitored by a single tracing vendor and stayed within the boundaries of a single platform provider. Today, an increasing number of applications are highly distributed and leverage multiple middleware services and cloud platforms.
 
-This transformation of modern applications calls for a distributed tracing
-context propagation standard.
+This transformation of modern applications calls for a distributed tracing context propagation standard.
 
 ## Solution
 
-The trace context specification defines a universally agreed-upon format for the
-exchange of trace context propagation data - referred to as *trace context*.
-Trace context solves the problems described above by
+The trace context specification defines a universally agreed-upon format for the exchange of trace context propagation data - referred to as *trace context*. Trace context solves the problems described above by
 
-- providing an unique identifier for individual traces and requests, allowing
-  trace data of multiple providers to be linked together.
-- providing an agreed-upon mechanism to forward vendor-specific trace data and
-  avoid broken traces when multiple trace tools participate in a single
-  transaction.
-- providing an industry standard that intermediaries, platforms, and hardware
-  providers can support.
+- providing an unique identifier for individual traces and requests, allowing trace data of multiple providers to be linked together.
+- providing an agreed-upon mechanism to forward vendor-specific trace data and avoid broken traces when multiple trace tools participate in a single transaction.
+- providing an industry standard that intermediaries, platforms, and hardware providers can support.
 
-A unified approach for propagating trace data improves visibility into the
-behavior of distributed applications, facilitating problem and performance
-analysis. The interoperability provided by trace-context is a prerequisite to
-manage modern micro-service based applications.
+A unified approach for propagating trace data improves visibility into the behavior of distributed applications, facilitating problem and performance analysis. The interoperability provided by trace-context is a prerequisite to manage modern micro-service based applications.
 
 ## Design overview
 
-Trace context is split into two individual propagation fields supporting
-interoperability and vendor-specific extensibility:
+Trace context is split into two individual propagation fields supporting interoperability and vendor-specific extensibility:
 
-- `traceparent` describes the position of the incoming request in its trace
-  graph in a portable, fixed-length format. Its design focuses on fast parsing.
-  Every tracing tool MUST properly set `tracestate` even when it only relies on
-  vendor-specific information in `tracestate`
-- `tracestate` extends `traceparent` with vendor-specific data represented by a
-  set of name/value pairs. Storing information in `tracestate` is optional.
+- `traceparent` describes the position of the incoming request in its trace graph in a portable, fixed-length format. Its design focuses on fast parsing. Every tracing tool MUST properly set `tracestate` even when it only relies on vendor-specific information in `tracestate`
+- `tracestate` extends `traceparent` with vendor-specific data represented by a set of name/value pairs. Storing information in `tracestate` is optional.
 
-Tracing tools can provide two levels of compliant behavior interacting with
-trace context:
+Tracing tools can provide two levels of compliant behavior interacting with trace context:
 
-- At a minimum they MUST propagate the `traceparent` and `tracestate` headers
-  and guarantee traces are not broken. this behavior is also referred to as
-  forwarding a trace.
-- In addition they CAN also choose to participate in a trace by modifying the
-  `traceparent` header and relevant parts of the `tracestate` header containing
-  their proprietary information. This is also referred to as participating in a
-  trace.
+- At a minimum they MUST propagate the `traceparent` and `tracestate` headers and guarantee traces are not broken. this behavior is also referred to as forwarding a trace.
+- In addition they CAN also choose to participate in a trace by modifying the `traceparent` header and relevant parts of the `tracestate` header containing their proprietary information. This is also referred to as participating in a trace.
 
-A tracing tool can choose to change this behavior for each individual request to
-a component it is monitoring.
+A tracing tool can choose to change this behavior for each individual request to a component it is monitoring.

--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -1,40 +1,30 @@
 # Trace context HTTP headers format
 
-This section describes the binding of the distributed trace context to
-`traceparent` and `tracestate` http headers.
+This section describes the binding of the distributed trace context to `traceparent` and `tracestate` http headers.
 
 ## Relationship between the headers
 
-The `traceparent` header represents the incoming request in a tracing system in
-a common format. The `tracestate` header includes the parent in a potentially
-vendor-specific format.
+The `traceparent` header represents the incoming request in a tracing system in a common format. The `tracestate` header includes the parent in a potentially vendor-specific format.
 
-For example, a client traced in the congo system adds the following headers to
-an outbound http request.
+For example, a client traced in the congo system adds the following headers to an outbound http request.
 
 ``` http
 traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
 tracestate: congo=t61rcWkgMzE
 ```
 
-Note: In this case, the value `t61rcWkgMzE`, is the result of Base64 encoding
-the parent ID (`b7ad6b7169203331`), though such manipulations are not required in
-`tracestate`.
+Note: In this case, the value `t61rcWkgMzE`, is the result of Base64 encoding the parent ID (`b7ad6b7169203331`), though such manipulations are not required in `tracestate`.
 
-If the receiving server is traced in the `rojo` tracing system, it carries over
-the state it received and adds a new entry with the position in its trace.
+If the receiving server is traced in the `rojo` tracing system, it carries over the state it received and adds a new entry with the position in its trace.
 
 ``` http
 traceparent: 00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01
 tracestate: rojo=00f067aa0ba902b7,congo=t61rcWkgMzE
 ```
 
-You'll notice that the `rojo` system reuses the value of `traceparent` in its
-entry in `tracestate`. This means it is a generic tracing system. Otherwise,
-`tracestate` entries are opaque.
+You'll notice that the `rojo` system reuses the value of `traceparent` in its entry in `tracestate`. This means it is a generic tracing system. Otherwise, `tracestate` entries are opaque.
 
-If the receiving server of the above is `congo` again, it continues from its
-last position, overwriting its entry with one representing the new parent.
+If the receiving server of the above is `congo` again, it continues from its last position, overwriting its entry with one representing the new parent.
 
 ``` http
 traceparent: 00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01
@@ -43,14 +33,9 @@ tracestate: congo=ucfJifl5GOE,rojo=00f067aa0ba902b7
 
 Note, `ucfJifl5GOE` is the Base64 encoded parent ID `b9c7c989f97918e1`.
 
-Notice when `congo` wrote its `traceparent` entry, it reuses the last parent ID
-which helps in consistency for those doing correlation. However, the value of
-its entry `tracestate` is opaque and different. This is ok.
+Notice when `congo` wrote its `traceparent` entry, it reuses the last parent ID which helps in consistency for those doing correlation. However, the value of its entry `tracestate` is opaque and different. This is ok.
 
-Finally, you'll see `tracestate` retains an entry for `rojo` exactly as it was,
-except pushed to the right. The left-most position lets the next server know
-which tracing system corresponds with `traceparent`. In this case, since `congo`
-wrote `traceparent`, its `tracestate` entry should be left-most.
+Finally, you'll see `tracestate` retains an entry for `rojo` exactly as it was, except pushed to the right. The left-most position lets the next server know which tracing system corresponds with `traceparent`. In this case, since `congo` wrote `traceparent`, its `tracestate` entry should be left-most.
 
 ## Traceparent field
 
@@ -58,21 +43,15 @@ Field `traceparent` identifies the request in a tracing system.
 
 ### Header name
 
-In order to increase interoperability across multiple protocols and encourage
-successful integration by default it is recommended to keep the header name
-lower case. Header name is a single word without any delimiters like hyphen
-(`-`).
+In order to increase interoperability across multiple protocols and encourage successful integration by default it is recommended to keep the header name lower case. Header name is a single word without any delimiters like hyphen (`-`).
 
 Header name: `traceparent`
 
-Platforms and libraries MUST expect header name in any casing and SHOULD send
-header name in lower case.
+Platforms and libraries MUST expect header name in any casing and SHOULD send header name in lower case.
 
 ### Field value
 
-This section uses the Augmented Backus-Naur Form (ABNF) notation of
-[[!RFC5234]], including the DIGIT rule from that document. `DIGIT` rule defines
-a single number character `0`-`9`.
+This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]], including the DIGIT rule from that document. `DIGIT` rule defines a single number character `0`-`9`.
 
 ``` abnf
 HEXDIGLC = DIGIT / "a" / "b" / "c" / "d" / "e" / "f" ; lower case hex character
@@ -80,11 +59,9 @@ value           = version "-" version-format
 version         = 2HEXDIGLC   ; this document assumes version 00. Version 255 is forbidden
 ```
 
-The value is US-ASCII encoded (which is UTF-8 compliant). Character `-` is used
-as a delimiter between fields.
+The value is US-ASCII encoded (which is UTF-8 compliant). Character `-` is used as a delimiter between fields.
 
-Version (`version`) is a 1 byte representing an 8-bit unsigned integer. Version
-`255` is invalid. Current specification assumes the `version` is set to `00`.
+Version (`version`) is a 1 byte representing an 8-bit unsigned integer. Version `255` is invalid. Current specification assumes the `version` is set to `00`.
 
 The following `version-format` definition is used for version `00`.
 
@@ -97,60 +74,33 @@ trace-flags      = 2HEXDIGLC   ; 8 bit flags. Currently only one bit is used. Se
 
 #### Trace-id
 
-This is the ID of the whole trace forest. It is represented as a 16-bytes array, for
-example, `4bf92f3577b34da6a3ce929d0e0e4736`. All bytes zero
-(`00000000000000000000000000000000`) is considered an invalid value.
+This is the ID of the whole trace forest. It is represented as a 16-bytes array, for example, `4bf92f3577b34da6a3ce929d0e0e4736`. All bytes zero (`00000000000000000000000000000000`) is considered an invalid value.
 
-`Trace-id` is used to uniquely identify a <a>distributed trace</a>. An
-implementation should generate globally unique values. Many algorithms of unique
-identification generation are based on some constant part - time or host based
-and a random value. There are systems that make random sampling decisions based
-on the value of `trace-id`. So to increase interoperability it is recommended to
-keep the random part on the right side of `trace-id` value.
+`Trace-id` is used to uniquely identify a <a>distributed trace</a>. An implementation should generate globally unique values. Many algorithms of unique identification generation are based on some constant part - time or host based and a random value. There are systems that make random sampling decisions based on the value of `trace-id`. So to increase interoperability it is recommended to keep the random part on the right side of `trace-id` value.
 
-When a system operates with a shorter `trace-id` - it is recommended to fill-in
-the extra bytes with random values rather than zeroes. Let's say the system
-works with a 8-byte `trace-id` like `3ce929d0e0e4736`. Instead of setting
-`trace-id` value to `0000000000000003ce929d0e0e4736` it is recommended to
-generate a value like `4bf92f3577b34da6a3ce929d0e0e4736` where
-`4bf92f3577b34da6a` is a random value or a function of time & host value. Note,
-even though a system may operate with a shorter `trace-id` for <a>distributed
-trace</a> reporting - full `trace-id` MUST be propagated to conform to the
-specification.
+When a system operates with a shorter `trace-id` - it is recommended to fill-in the extra bytes with random values rather than zeroes. Let's say the system works with a 8-byte `trace-id` like `3ce929d0e0e4736`. Instead of setting `trace-id` value to `0000000000000003ce929d0e0e4736` it is recommended to generate a value like `4bf92f3577b34da6a3ce929d0e0e4736` where `4bf92f3577b34da6a` is a random value or a function of time & host value. Note, even though a system may operate with a shorter `trace-id` for <a>distributed trace</a> reporting - full `trace-id` MUST be propagated to conform to the specification.
 
-Implementations HAVE TO ignore the `traceparent` when the `trace-id` is invalid.
-For instance, if it contains non-allowed characters.
+Implementations HAVE TO ignore the `traceparent` when the `trace-id` is invalid. For instance, if it contains non-allowed characters.
 
 #### Parent-id
 
-This is the ID of this call as known by the caller. It is also known as `span-id` as
-a few telemetry systems call the execution of a client call a span. It is
-represented as an 8-byte array, for example, `00f067aa0ba902b7`. All bytes zero
-(`0000000000000000`) is considered an invalid value.
+This is the ID of this call as known by the caller. It is also known as `span-id` as a few telemetry systems call the execution of a client call a span. It is represented as an 8-byte array, for example, `00f067aa0ba902b7`. All bytes zero (`0000000000000000`) is considered an invalid value.
 
-Implementations HAVE TO ignore the `traceparent` when the `parent-id` is
-invalid. For instance, if it contains non lower case hex characters.
+Implementations HAVE TO ignore the `traceparent` when the `parent-id` is invalid. For instance, if it contains non lower case hex characters.
 
 ### Trace-flags
 
-An <a data-cite='!BIT-FIELD'>8-bit field</a> that controls tracing flags such as
-sampling, trace level etc. These flags are recommendations given by the caller
-rather than strict rules to follow for three reasons:
+An <a data-cite='!BIT-FIELD'>8-bit field</a> that controls tracing flags such as sampling, trace level etc. These flags are recommendations given by the caller rather than strict rules to follow for three reasons:
 
 1. Trust and abuse
 2. Bug in caller
-3. Different load between caller service and callee service might force callee
-   to downsample.
+3. Different load between caller service and callee service might force callee to downsample.
 
 You can find more in the section [Security considerations](#security-considerations) of this specification.
 
-Like other fields, `trace-flags` is hex-encoded. For example, all `8` flags set
-would be `ff` and no flags set would be `00`.
+Like other fields, `trace-flags` is hex-encoded. For example, all `8` flags set would be `ff` and no flags set would be `00`.
 
-As this is a bit field, you cannot interpret flags by decoding the hex value and
-looking at the resulting number. For example, a flag `00000001` could be encoded
-as `01` in hex, or `09` in hex if present with the flag `00001000`. A common
-mistake in bit fields is forgetting to mask when interpreting flags.
+As this is a bit field, you cannot interpret flags by decoding the hex value and looking at the resulting number. For example, a flag `00000001` could be encoded as `01` in hex, or `09` in hex if present with the flag `00001000`. A common mistake in bit fields is forgetting to mask when interpreting flags.
 
 Here is an example of properly handing trace flags:
 
@@ -164,63 +114,27 @@ Current version of specification only supports a single flag called `sampled`.
 
 #### Sampled Flag (00000001)
 
-When set, the least significant bit documents that the caller may have recorded
-trace data. A caller who does not record trace data out-of-band leaves this flag
-unset.
+When set, the least significant bit documents that the caller may have recorded trace data. A caller who does not record trace data out-of-band leaves this flag unset.
 
-Many distributed tracing scenarios may be broken when only a subset of calls
-participated in a <a>distributed trace</a> were recorded. At certain load
-recording information about every incoming and outgoing request becomes
-prohibitively expensive. Making a random or component-specific decision for data
-collection will lead to fragmented data in every <a>distributed trace</a>. Thus
-it is typical for tracing vendors and platforms to pass recording decision for
-given distributed trace or information needed to make this decision.
+Many distributed tracing scenarios may be broken when only a subset of calls participated in a <a>distributed trace</a> were recorded. At certain load recording information about every incoming and outgoing request becomes prohibitively expensive. Making a random or component-specific decision for data collection will lead to fragmented data in every <a>distributed trace</a>. Thus it is typical for tracing vendors and platforms to pass recording decision for given distributed trace or information needed to make this decision.
 
-There is no consensus on what is the best algorithm to make a recording
-decision. Various techniques include: probability sampling (sample 1 out of 100
-<a>distributed traces</a> by flipping a coin), delayed decision (make collection
-decision based on duration or a result of a call), deferred sampling (let callee
-decide whether information about this request need to be collected). There are
-variations and customizations of every technique which can be tracing vendor
-specific or application defined.
+There is no consensus on what is the best algorithm to make a recording decision. Various techniques include: probability sampling (sample 1 out of 100 <a>distributed traces</a> by flipping a coin), delayed decision (make collection decision based on duration or a result of a call), deferred sampling (let callee decide whether information about this request need to be collected). There are variations and customizations of every technique which can be tracing vendor specific or application defined.
 
-Field `tracestate` is designed to handle the variety of techniques for making
-recording decision specific (along any other specific information) for a given
-tracing system or a platform. Flag `sampled` is introduced for better
-interoperability between vendors. It allows to communicate recording decision
-and enable better experience for the customer.
+Field `tracestate` is designed to handle the variety of techniques for making recording decision specific (along any other specific information) for a given tracing system or a platform. Flag `sampled` is introduced for better interoperability between vendors. It allows to communicate recording decision and enable better experience for the customer.
 
-For example, when SaaS services participate in <a>distributed trace</a> - this
-service has no knowledge of tracing system used by its caller. But this service
-may produce records of incoming requests for monitoring or troubleshooting
-purposes. Flag `sampled` can be used to ensure that information about requests
-that were marked for recording by caller will also be recorded by SaaS service.
-So caller can troubleshoot the behavior of every recorded request.
+For example, when SaaS services participate in <a>distributed trace</a> - this service has no knowledge of tracing system used by its caller. But this service may produce records of incoming requests for monitoring or troubleshooting purposes. Flag `sampled` can be used to ensure that information about requests that were marked for recording by caller will also be recorded by SaaS service. So caller can troubleshoot the behavior of every recorded request.
 
-Flag `sampled` has no restriction on its mutations except that it can only be
-mutated when `parent-id` was updated. See section "Mutating the traceparent
-field". However there are set of suggestions that will increase vendors
-interoperability.
+Flag `sampled` has no restriction on its mutations except that it can only be mutated when `parent-id` was updated. See section "Mutating the traceparent field". However there are set of suggestions that will increase vendors interoperability.
 
-1. If component made definitive recording decision - this decision SHOULD be
-   reflected in `sampled` flag.
-2. If component needs to make a recording decision - it SHOULD respect
-   `sampled` flag value. Security considerations should be applied to protect
-   from abusive or malicious use of this flag - see security section.
-3. If component deferred or delayed decision and only a subset of telemetry will
-   be recorded - flag `sampled` should be propagated unchanged. And set to `0`
-   as a default option when trace is initiated by this component. There are two
-   additional options:
-    1. Component that makes deferred or delayed recording decision may
-       communicate priority of recording by setting `sampled` flag to `1` for a
-       subset of requests.
-    2. Component may also fall back to probability sampling to set flag
-       `sampled` to `1` for the subset of requests.
+1. If component made definitive recording decision - this decision SHOULD be reflected in `sampled` flag.
+2. If component needs to make a recording decision - it SHOULD respect `sampled` flag value. Security considerations should be applied to protect from abusive or malicious use of this flag - see security section.
+3. If component deferred or delayed decision and only a subset of telemetry will be recorded - flag `sampled` should be propagated unchanged. And set to `0` as a default option when trace is initiated by this component. There are two additional options:
+    1. Component that makes deferred or delayed recording decision may communicate priority of recording by setting `sampled` flag to `1` for a subset of requests.
+    2. Component may also fall back to probability sampling to set flag `sampled` to `1` for the subset of requests.
 
 #### Other Flags
 
-The behavior of other flags, such as (`00000100`) is not defined and reserved
-for future use. Implementations MUST set those to zero.
+The behavior of other flags, such as (`00000100`) is not defined and reserved for future use. Implementations MUST set those to zero.
 
 ### Examples of HTTP headers
 
@@ -246,93 +160,47 @@ base16(trace-flags) = 00  // not sampled
 
 ### Versioning of `traceparent`
 
-This specification is opinionated about future version of the trace context.
-Current version of this specification assumes that the future versions of
-`traceparent` header will be additive to the current one.
+This specification is opinionated about future version of the trace context. Current version of this specification assumes that the future versions of `traceparent` header will be additive to the current one.
 
-Implementations should follow the following rules when parsing headers with an
-unexpected format:
+Implementations should follow the following rules when parsing headers with an unexpected format:
 
-1. Pass thru services should not analyze version. Pass thru service needs to
-   expect that headers may have bigger size limits in the future and only
-   disallow prohibitively large headers.
-2. When version prefix cannot be parsed (it's not 2 hex characters followed by
-   dash (`-`)), implementation should restart the trace.
+1. Pass thru services should not analyze version. Pass thru service needs to expect that headers may have bigger size limits in the future and only disallow prohibitively large headers.
+2. When version prefix cannot be parsed (it's not 2 hex characters followed by dash (`-`)), implementation should restart the trace.
 3. If higher version is detected - implementation SHOULD try to parse it.
-    1. If the size of header is shorter than 55 characters -implementation
-       should not parse header and should restart the trace.
-    2. Try parsing `trace-id`: from the first dash - next 32 characters.
-       Implementations MUST check 32 characters to be hex. Make sure they are
-       followed by dash.
-    3. Try parsing `parent-id`: from the second dash at 35th position - 16
-       characters. Implementations MUST check 16 characters to be hex. Make sure
-       this is followed by a dash.
-    4. Try parsing the `sampled` bit of `trace-flags`:  2 characters from third dash.
-       Following with either end of string or a dash. If all three values were
-       parsed successfully - implementation should use them.
+    1. If the size of header is shorter than 55 characters -implementation should not parse header and should restart the trace.
+    2. Try parsing `trace-id`: from the first dash - next 32 characters. Implementations MUST check 32 characters to be hex. Make sure they are followed by dash.
+    3. Try parsing `parent-id`: from the second dash at 35th position - 16 characters. Implementations MUST check 16 characters to be hex. Make sure this is followed by a dash.
+    4. Try parsing the `sampled` bit of `trace-flags`:  2 characters from third dash. Following with either end of string or a dash. If all three values were parsed successfully - implementation should use them.
 
-Implementations MUST NOT parse or assume anything about any fields unknown for
-this version. Implementations MUST use these fields to construct the new
-`traceparent` field according to the highest version of the specification known
-to the implementation (in this specification it is `00`).
+Implementations MUST NOT parse or assume anything about any fields unknown for this version. Implementations MUST use these fields to construct the new `traceparent` field according to the highest version of the specification known to the implementation (in this specification it is `00`).
 
 ## Tracestate field
 
-The `tracestate` HTTP header field conveys information about request position in
-multiple distributed tracing graphs. This header is a companion header for the
-`traceparent`. If library or platform failed to parse `traceparent` - it MUST
-NOT attempt to parse the `tracestate`. Note, that opposite it not true - failure
-to parse `tracestate` MUST NOT affect the parsing of `traceparent`.
+The `tracestate` HTTP header field conveys information about request position in multiple distributed tracing graphs. This header is a companion header for the `traceparent`. If library or platform failed to parse `traceparent` - it MUST NOT attempt to parse the `tracestate`. Note, that opposite it not true - failure to parse `tracestate` MUST NOT affect the parsing of `traceparent`.
 
 ### Header name
 
-In order to increase interoperability across multiple protocols and encourage
-successful integration by default it is recommended to keep the header name
-lower case. Header name is a single word without any delimiters like hyphen
-(`-`).
+In order to increase interoperability across multiple protocols and encourage successful integration by default it is recommended to keep the header name lower case. Header name is a single word without any delimiters like hyphen (`-`).
 
 Header name: `tracestate`
 
-Platforms and libraries MUST expect header name in any casing and SHOULD send
-header name in lower case.
+Platforms and libraries MUST expect header name in any casing and SHOULD send header name in lower case.
 
 ### Header value
 
-Multiple `tracestate` headers are allowed. Values from multiple headers in
-incoming requests SHOULD be combined in a single header according to <a
-data-cite='!RFC7230#page-24'>Field Order</a> [[!RFC7230]] and send as a single
-header in outgoing request.
+Multiple `tracestate` headers are allowed. Values from multiple headers in incoming requests SHOULD be combined in a single header according to <a data-cite='!RFC7230#page-24'>Field Order</a> [[!RFC7230]] and send as a single header in outgoing request.
 
-This section uses the Augmented Backus-Naur Form (ABNF) notation of
-[[!RFC5234]], including the DIGIT rule in <a
-data-cite='!RFC5234#appendix-B.1'>appendix B.1 for RFC5234</a>. It also includes
-the `OWS` rule from <a data-cite='!RFC7230#section-3.2.3'>RFC7230 section
-3.2.3</a>.
+This section uses the Augmented Backus-Naur Form (ABNF) notation of [[!RFC5234]], including the DIGIT rule in <a data-cite='!RFC5234#appendix-B.1'>appendix B.1 for RFC5234</a>. It also includes the `OWS` rule from <a data-cite='!RFC7230#section-3.2.3'>RFC7230 section 3.2.3</a>.
 
 `DIGIT` rule defines number `0`-`9`.
 
-The `OWS` rule defines an optional whitespace. It is used where zero or more
-whitespace characters might appear. When it is preferred to improve readability
-- a sender SHOULD generate the optional whitespace as a single space; otherwise,
-a sender SHOULD NOT generate optional whitespace. See details in corresponding
-RFC.
+The `OWS` rule defines an optional whitespace. It is used where zero or more whitespace characters might appear. When it is preferred to improve readability - a sender SHOULD generate the optional whitespace as a single space; otherwise, a sender SHOULD NOT generate optional whitespace. See details in corresponding RFC.
 
-The `tracestate` field value is a `list` as defined below. The `list` is a
-series of `list-members` separated by commas `,`, and a `list-member` is a
-key/value pair separated by an equals sign `=`. Spaces and horizontal tabs
-surrounding `list-member`s are ignored. There can be a maximum of 32
-`list-member`s in a `list`.
+The `tracestate` field value is a `list` as defined below. The `list` is a series of `list-members` separated by commas `,`, and a `list-member` is a key/value pair separated by an equals sign `=`. Spaces and horizontal tabs surrounding `list-member`s are ignored. There can be a maximum of 32 `list-member`s in a `list`.
 
-Empty and whitespace-only list members are allowed. Libraries and platforms MUST
-accept empty `tracestate` headers, but SHOULD avoid sending them. The reason for
-allowing of empty list members in `tracestate` is a difficulty for implementor
-to recognize the empty value when multiple `tracestate` headers were sent.
-Whitespace characters are allowed for a similar reason as some frameworks will
-inject whitespace after `,` separator automatically even in case of an empty
-header.
+Empty and whitespace-only list members are allowed. Libraries and platforms MUST accept empty `tracestate` headers, but SHOULD avoid sending them. The reason for allowing of empty list members in `tracestate` is a difficulty for implementor to recognize the empty value when multiple `tracestate` headers were sent. Whitespace characters are allowed for a similar reason as some frameworks will inject whitespace after `,` separator automatically even in case of an empty header.
 
-A simple example of a `list` with two `list-member`s might look like:
-`vendorname1=opaqueValue1,vendorname2=opaqueValue2`.
+A simple example of a `list` with two `list-member`s might look like: `vendorname1=opaqueValue1,vendorname2=opaqueValue2`.
 
 ``` abnf
 list  = list-member 0*31( OWS "," OWS list-member )
@@ -348,17 +216,9 @@ key = lcalpha 0*240( lcalpha / DIGIT / "_" / "-"/ "*" / "/" ) "@" lcalpha 0*13( 
 lcalpha    = %x61-7A ; a-z
 ```
 
-Note that identifiers MUST begin with a lowercase letter, and can only contain
-lowercase letters `a`-`z`, digits `0`-`9`, underscores `_`, dashes `-`,
-asterisks `*`, and forward slashes `/`. For multi-tenant vendors scenarios `@`
-sign can be used to prefix vendor name. Suggested use is to allow set tenant id
-in the beginning of key like `fw529a3039@dt` - `fw529a3039` is a tenant id and
-`@dt` is a vendor name. Searching for `@dt=` would be more robust for parsing
-(searching for all vendor's keys).
+Note that identifiers MUST begin with a lowercase letter, and can only contain lowercase letters `a`-`z`, digits `0`-`9`, underscores `_`, dashes `-`, asterisks `*`, and forward slashes `/`. For multi-tenant vendors scenarios `@` sign can be used to prefix vendor name. Suggested use is to allow set tenant id in the beginning of key like `fw529a3039@dt` - `fw529a3039` is a tenant id and `@dt` is a vendor name. Searching for `@dt=` would be more robust for parsing (searching for all vendor's keys).
 
-Value is opaque string up to 256 characters printable ASCII [[!RFC0020]]
-characters (i.e., the range 0x20 to 0x7E) except comma `,` and `=`. Note that
-this also excludes tabs, newlines, carriage returns, etc.
+Value is opaque string up to 256 characters printable ASCII [[!RFC0020]] characters (i.e., the range 0x20 to 0x7E) except comma `,` and `=`. Note that this also excludes tabs, newlines, carriage returns, etc.
 
 ``` abnf
 value    = 0*255(chr) nblk-chr
@@ -366,50 +226,27 @@ nblk-chr = %x21-2B / %x2D-3C / %x3E-7E
 chr      = %x20 / nblk-chr
 ```
 
-The length of a combined header MUST be less than or equal to 512 bytes. If the
-length of a combined header is more than 512 bytes it SHOULD be ignored.
+The length of a combined header MUST be less than or equal to 512 bytes. If the length of a combined header is more than 512 bytes it SHOULD be ignored.
 
 Example: `vendorname1=opaqueValue1,vendorname2=opaqueValue2`
 
-The value of a concatenation of trace graph key-value pairs. Only one entry per
-key is allowed because the entry represents that last position in the trace.
-Hence implementors must overwrite their entry upon reentry to their tracing
-system.
+The value of a concatenation of trace graph key-value pairs. Only one entry per key is allowed because the entry represents that last position in the trace. Hence implementors must overwrite their entry upon reentry to their tracing system.
 
-For example, if tracing system name is `congo`, and a trace started in their
-system, went through a system named `rojo` and later returned to `congo`, the
-`tracestate` value would not be:
+For example, if tracing system name is `congo`, and a trace started in their system, went through a system named `rojo` and later returned to `congo`, the `tracestate` value would not be:
 
 `congo=congosFirstPosition,rojo=rojosFirstPosition,congo=congosSecondPosition`
 
-Rather, the entry would be rewritten to only include the most recent position:
-`congo=congosSecondPosition,rojo=rojosFirstPosition`
+Rather, the entry would be rewritten to only include the most recent position: `congo=congosSecondPosition,rojo=rojosFirstPosition`
 
 **Limits:**
 
-The `tracestate` field contains essential information for request correlation.
-Platforms and tracing systems MUST propagate this field. There might be multiple
-`tracestate` headers in a single request according to [RFC7230 section
-3.2.2](https://tools.ietf.org/html/rfc7230#section-3.2.2). Platform or tracing
-system may propagate them as they came, combine into a single header or split
-into multiple headers differently following the RFC specification.
+The `tracestate` field contains essential information for request correlation. Platforms and tracing systems MUST propagate this field. There might be multiple `tracestate` headers in a single request according to [RFC7230 section 3.2.2](https://tools.ietf.org/html/rfc7230#section-3.2.2). Platform or tracing system may propagate them as they came, combine into a single header or split into multiple headers differently following the RFC specification.
 
-Platforms and tracing vendors SHOULD propagate at least 512 characters of a
-combined header. This length includes commas required to separate list items.
-But does not include optional white space (`OWA`) characters.
+Platforms and tracing vendors SHOULD propagate at least 512 characters of a combined header. This length includes commas required to separate list items. But does not include optional white space (`OWA`) characters.
 
-There are systems where propagating of 512 characters of `tracestate` may be
-expensive. In this case the maximum size of propagated `tracestate` header
-SHOULD be documented and explained. Cost of propagating `tracestate` SHOULD be
-weighted against the value of monitoring scenarios enabled for the end users.
+There are systems where propagating of 512 characters of `tracestate` may be expensive. In this case the maximum size of propagated `tracestate` header SHOULD be documented and explained. Cost of propagating `tracestate` SHOULD be weighted against the value of monitoring scenarios enabled for the end users.
 
-In situation when `tracestate` needs to be truncated due to size limitations,
-platform of tracing vendor MUST truncate whole entries. Entries larger than
-`128` characters long SHOULD be removed first. Then entries SHOULD be removed
-starting from the end of `tracestate`. Note, other truncation strategies like
-safe list entries, blocked list entries or size-based truncation MAY be used,
-but highly discouraged. Those strategies will decrease interoperability of
-various tracing vendors.
+In situation when `tracestate` needs to be truncated due to size limitations, platform of tracing vendor MUST truncate whole entries. Entries larger than `128` characters long SHOULD be removed first. Then entries SHOULD be removed starting from the end of `tracestate`. Note, other truncation strategies like safe list entries, blocked list entries or size-based truncation MAY be used, but highly discouraged. Those strategies will decrease interoperability of various tracing vendors.
 
 ### Examples of HTTP headers
 
@@ -427,75 +264,29 @@ tracestate: rojo=00f067aa0ba902b7,congo=t61rcWkgMzE
 
 ### Versioning of `tracestate`
 
-Version of `tracestate` is defined by the version prefix of `traceparent`
-header. Implementations needs to attempt parsing of `tracestate` if a higher
-version is detected to the best of its ability. It is the implementor's decision
-whether to use partially-parsed `tracestate` key-value pairs or not.
+Version of `tracestate` is defined by the version prefix of `traceparent` header. Implementations needs to attempt parsing of `tracestate` if a higher version is detected to the best of its ability. It is the implementor's decision whether to use partially-parsed `tracestate` key-value pairs or not.
 
 ## Mutating the traceparent field
 
-Library or platform receiving `traceparent` request header MUST send it to
-outgoing requests. It MAY mutate the value of this header before passing to
-outgoing requests.
+Library or platform receiving `traceparent` request header MUST send it to outgoing requests. It MAY mutate the value of this header before passing to outgoing requests.
 
-If the value of the `traceparent` field wasn't changed before propagation -
-`tracestate` MUST NOT be modified as well. Unmodified headers propagation is
-typically implemented in pass-thru services like proxies. This behavior may also
-be implemented in a service which currently does not collect distributed tracing
-information.
+If the value of the `traceparent` field wasn't changed before propagation - `tracestate` MUST NOT be modified as well. Unmodified headers propagation is typically implemented in pass-thru services like proxies. This behavior may also be implemented in a service which currently does not collect distributed tracing information.
 
 Here is the list of allowed mutations:
 
-1. **Update `parent-id`**. The value of property `parent-id` can be set to the
-   new value representing the ID of the current operation. This is the most
-   typical mutation and should be considered a default.
-2. **Update `sampled`**. The value of `sampled` reflects the caller's recording
-   behavior: either trace data was dropped or may have been recorded out-of-band -
-   this can be indicated by toggling the flag in both directions. This mutation
-   gives the downstream tracer information about the likelihood its parent's
-   information was recorded. `parent-id` MUST be set to a new value with the
-   `sampled` flag update. See details of the [`sampled` flag](#sampled-flag-00000001)
-   for more information on how it is recommended to be used.
-3. **Restart trace**. All properties - `trace-id`, `parent-id`, `trace-flags`
-   are regenerated. The typical use of this mutation is addressing
-   [privacy](#privacy-considerations) or [security](#security-considerations)
-   considerations. For example, this mutation is used in the services defined as
-   a front gate into trust boundaries of an application and eliminates a
-   potential denial of service attack surface. Implementations SHOULD clean up
-   `tracestate` collection on `traceparent` restart. There are rare cases when
-   the original `tracestate` entries must be preserved after restart. Typically,
-   when `trace-id` will be reverted back at some point of the trace flow - for
-   instance, when it leaves the trust boundaries of an application in the
-   example above. However, it SHOULD be an explicit decision, not a default
-   behavior. As trace vendors may rely on `trace-id` matching `tracestate`
-   values.
-4. **Downgrade the version**. Current version of specification defines the
-   behavior for implementation that receives a `traceparent` header of a higher
-   version. See [versioning of `traceparent`](#versioning-of-traceparent)
-   section. In this case the first mutation will be to downgrade the version of
-   the header. Other mutations are allowed in combination with this one.
+1. **Update `parent-id`**. The value of property `parent-id` can be set to the new value representing the ID of the current operation. This is the most typical mutation and should be considered a default.
+2. **Update `sampled`**. The value of `sampled` reflects the caller's recording behavior: either trace data was dropped or may have been recorded out-of-band - this can be indicated by toggling the flag in both directions. This mutation gives the downstream tracer information about the likelihood its parent's information was recorded. `parent-id` MUST be set to a new value with the `sampled` flag update. See details of the [`sampled` flag](#sampled-flag-00000001) for more information on how it is recommended to be used.
+3. **Restart trace**. All properties - `trace-id`, `parent-id`, `trace-flags` are regenerated. The typical use of this mutation is addressing [privacy](#privacy-considerations) or [security](#security-considerations) considerations. For example, this mutation is used in the services defined as a front gate into trust boundaries of an application and eliminates a potential denial of service attack surface. Implementations SHOULD clean up `tracestate` collection on `traceparent` restart. There are rare cases when the original `tracestate` entries must be preserved after restart. Typically, when `trace-id` will be reverted back at some point of the trace flow - for instance, when it leaves the trust boundaries of an application in the example above. However, it SHOULD be an explicit decision, not a default behavior. As trace vendors may rely on `trace-id` matching `tracestate` values.
+4. **Downgrade the version**. Current version of specification defines the behavior for implementation that receives a `traceparent` header of a higher version. See [versioning of `traceparent`](#versioning-of-traceparent) section. In this case the first mutation will be to downgrade the version of the header. Other mutations are allowed in combination with this one.
 
-Libraries and platforms MUST NOT make any other mutations to the `traceparent`
-header.
+Libraries and platforms MUST NOT make any other mutations to the `traceparent` header.
 
 ## Mutating the tracestate field
 
-Library or platform receiving `tracestate` request header MUST send it to
-outgoing requests. It MAY mutate the value of this header before passing to
-outgoing requests. The main concept of `tracestate` mutations is that the order
-of unmodified key-value pairs MUST be preserved. Modified keys MUST be moved to
-the beginning of the list.
+Library or platform receiving `tracestate` request header MUST send it to outgoing requests. It MAY mutate the value of this header before passing to outgoing requests. The main concept of `tracestate` mutations is that the order of unmodified key-value pairs MUST be preserved. Modified keys MUST be moved to the beginning of the list.
 
 Here is the list of allowed mutations:
 
-1. **Update key value**. The value of any key can be updated. Modified keys MUST
-   be moved to the beginning of the list. This is the most common mutation
-   resuming the trace.
-2. **Add new key-value pair**. New key-value pair should be added into the
-   beginning of the list.
-3. **Delete the key-value pair**. Any key-value pair MAY be deleted. It is
-   highly discouraged to delete keys that weren't generated by the same tracing
-   system or platform. Deletion of unknown key-value pair will break correlation
-   in other systems. This mutation enables two scenarios. The first is proxies
-   can block certain `tracestate` keys for privacy and security concerns. The
-   second scenario is a truncation of long `tracestate`'s.
+1. **Update key value**. The value of any key can be updated. Modified keys MUST be moved to the beginning of the list. This is the most common mutation resuming the trace.
+2. **Add new key-value pair**. New key-value pair should be added into the beginning of the list.
+3. **Delete the key-value pair**. Any key-value pair MAY be deleted. It is highly discouraged to delete keys that weren't generated by the same tracing system or platform. Deletion of unknown key-value pair will break correlation in other systems. This mutation enables two scenarios. The first is proxies can block certain `tracestate` keys for privacy and security concerns. The second scenario is a truncation of long `tracestate`'s.

--- a/spec/21-http_header_format_rationale.md
+++ b/spec/21-http_header_format_rationale.md
@@ -1,239 +1,120 @@
 # Trace context HTTP header format rationale
 
-This document provides rationale for the decisions made, mapping the
-`traceparent` and `tracestate` fields to HTTP headers.
+This document provides rationale for the decisions made, mapping the `traceparent` and `tracestate` fields to HTTP headers.
 
 ## Lowercase concatenated header names
 
-While HTTP headers are conventionally delimited by hyphens, the trace context
-header names are not. Rather, they are lowercase concatenated `traceparent` and
-`tracestate` respectively. The departure from convention is due to practical
-concerns of propagation. Trace context is unlike typical HTTP headers, which are
-point-to-point and do not propagate through other systems like messaging.
-Different systems have different constraints. For example, some cannot read case
-insensitively, and others forbid the hyphen character. Even if we could suggest
-not using the same format for such systems, we know many systems transparently
-copy HTTP headers into fields. This class of concerns only exist when we choose
-to support mixed case with hyphens. By choosing not to, we open trace context
-integration beyond HTTP at the cost of a conventional distraction.
+While HTTP headers are conventionally delimited by hyphens, the trace context header names are not. Rather, they are lowercase concatenated `traceparent` and `tracestate` respectively. The departure from convention is due to practical concerns of propagation. Trace context is unlike typical HTTP headers, which are point-to-point and do not propagate through other systems like messaging. Different systems have different constraints. For example, some cannot read case insensitively, and others forbid the hyphen character. Even if we could suggest not using the same format for such systems, we know many systems transparently copy HTTP headers into fields. This class of concerns only exist when we choose to support mixed case with hyphens. By choosing not to, we open trace context integration beyond HTTP at the cost of a conventional distraction.
 
 ## All parts of `traceparent` are required
 
-We've been discussing to make parts of the `traceparent` header optional. One
-proposal we declined was to allow trace-id-only `traceparent` headers. The
-intended use was to save size for small clients (like mobile devices) initiating
-the call. The rationale for declining it was to avoid abuse and confusion. A
-suggestion that we want to discuss on saving size is to use binary format.
+We've been discussing to make parts of the `traceparent` header optional. One proposal we declined was to allow trace-id-only `traceparent` headers. The intended use was to save size for small clients (like mobile devices) initiating the call. The rationale for declining it was to avoid abuse and confusion. A suggestion that we want to discuss on saving size is to use binary format.
 
-Making `trace-flags` optional doesn't save a lot, but makes specification more
-complicated. And it potentially can lead to incompatible implementations which
-do not expect `trace-flags`.
+Making `trace-flags` optional doesn't save a lot, but makes specification more complicated. And it potentially can lead to incompatible implementations which do not expect `trace-flags`.
 
 ## Span/parent nomenclature
 
-We were using the term `span-id` in the `traceparent`, but not all tracing
-systems are built around span model, e.g. X-Trace, Canopy, SolarWinds, are built
-around event model, which is considered more expressive than the span model.
-There is nothing in the spec actually requires the model to be span-based, and
-passing the ID of the happened-before "thing" should work for both types of
-trace models. We considered names `call-id`, `request-id`. However out of all
-replacements `parent-id` is probably the best name. First, it matched the header
-name. Second it indicates a difference between caller and callee. Discussing
-AMQP we realized that `message-id` header defined by AMQP refers to individual
-message, and semantically not the same as traceparent. Message id can be used to
-dedup messages on the server when traceparent only defines the source this
-message came from.
+We were using the term `span-id` in the `traceparent`, but not all tracing systems are built around span model, e.g. X-Trace, Canopy, SolarWinds, are built around event model, which is considered more expressive than the span model. There is nothing in the spec actually requires the model to be span-based, and passing the ID of the happened-before "thing" should work for both types of trace models. We considered names `call-id`, `request-id`. However out of all replacements `parent-id` is probably the best name. First, it matched the header name. Second it indicates a difference between caller and callee. Discussing AMQP we realized that `message-id` header defined by AMQP refers to individual message, and semantically not the same as traceparent. Message id can be used to dedup messages on the server when traceparent only defines the source this message came from.
 
 ## Ordering of keys in `tracestate`
 
-The specification calls for ordering of values in tracestate. This requirement
-allows better interoperability between tracing vendors.
+The specification calls for ordering of values in tracestate. This requirement allows better interoperability between tracing vendors.
 
-A typical <a>distributed trace</a> is clustered - components calling each other
-are often monitored by the same tracing vendor. So information supplied by the
-tracing system which originated a request will typically be less and less
-important deeper in a <a>distributed trace</a>. Immediate caller's information
-on the other hand typically is more valuable as it is more likely being
-monitored by the same tracing vendor. Thus, it is logical to move immediate
-caller's information to the beginning of the `tracestate` list. So less
-important values will be pushed to the end of the list.
+A typical <a>distributed trace</a> is clustered - components calling each other are often monitored by the same tracing vendor. So information supplied by the tracing system which originated a request will typically be less and less important deeper in a <a>distributed trace</a>. Immediate caller's information on the other hand typically is more valuable as it is more likely being monitored by the same tracing vendor. Thus, it is logical to move immediate caller's information to the beginning of the `tracestate` list. So less important values will be pushed to the end of the list.
 
-This prioritization of `tracestate` values improves performance of querying the
-value of tracestate - typically you only need a first pair. It also allows you
-to meaningfully truncate `tracestate` when required instead of dropping the
-entire list of values.
+This prioritization of `tracestate` values improves performance of querying the value of tracestate - typically you only need a first pair. It also allows you to meaningfully truncate `tracestate` when required instead of dropping the entire list of values.
 
 ## Mutations of `tracestate`
 
-Two questions that comes up frequently is whether the `tracestate` header HAVE
-TO be mutated on every mutation of `parent-id` to identify the vendor which made
-this change and whether two different vendors can modify the `tracestate`
-entries in a single component.
+Two questions that comes up frequently is whether the `tracestate` header HAVE TO be mutated on every mutation of `parent-id` to identify the vendor which made this change and whether two different vendors can modify the `tracestate` entries in a single component.
 
-This requirement may improve interoperability between vendors. For instance, a
-vendor may check the first `tracestate` key and provide some additional value
-for the customer by adjusting data collection in the current component via the
-knowledge of a caller's behavior. For instance, applying specific sampling
-policies or providing an experience for customers to get data from the caller's
-vendor. There are more scenarios that might be simplified by strict mutation
-requirements.
+This requirement may improve interoperability between vendors. For instance, a vendor may check the first `tracestate` key and provide some additional value for the customer by adjusting data collection in the current component via the knowledge of a caller's behavior. For instance, applying specific sampling policies or providing an experience for customers to get data from the caller's vendor. There are more scenarios that might be simplified by strict mutation requirements.
 
-Even though improved interoperability will enable more scenarios, the
-specification does not restrict the number of mutations of `tracestate` and
-doesn't require the mutation.
+Even though improved interoperability will enable more scenarios, the specification does not restrict the number of mutations of `tracestate` and doesn't require the mutation.
 
-The main reason for not requiring the mutation is generic tracers. Generic
-tracers are tracers which don't need to carry any information via `tracestate`
-and/or don't have a single back-end where this data will be stored. The only
-thing a generic tracer can set in `tracestate` is either a key with some
-constant, an empty value or a copy of  `traceparent`. Neither of those details
-is particularly interesting for the callee. But a requirement puts an extra
-burden and complexity on implementors. Another reason for not requiring a
-mutation is that allowing multiple mutations may require vendors to check for
-more than one key anyway.
+The main reason for not requiring the mutation is generic tracers. Generic tracers are tracers which don't need to carry any information via `tracestate` and/or don't have a single back-end where this data will be stored. The only thing a generic tracer can set in `tracestate` is either a key with some constant, an empty value or a copy of  `traceparent`. Neither of those details is particularly interesting for the callee. But a requirement puts an extra burden and complexity on implementors. Another reason for not requiring a mutation is that allowing multiple mutations may require vendors to check for more than one key anyway.
 
-Some back-end neutral SDKs may be implemented so that destination back-end is
-decided via side-car or out-of-process agent configuration. In such cases a
-customer may decide to enable more than one headers' mutation logic in
-in-process SDK. Another requirement for multiple mutations is that in a similar
-environment where the back-end destination is decided via out-of-process
-configuration - certain header mutations may still be required. An example may
-be smart sampling mechanisms that rely on additional data propagation in
-`tracestate`.
+Some back-end neutral SDKs may be implemented so that destination back-end is decided via side-car or out-of-process agent configuration. In such cases a customer may decide to enable more than one headers' mutation logic in in-process SDK. Another requirement for multiple mutations is that in a similar environment where the back-end destination is decided via out-of-process configuration - certain header mutations may still be required. An example may be smart sampling mechanisms that rely on additional data propagation in `tracestate`.
 
 ## Size limits of `tracestate`
 
 ### Total size limit
 
-The field `tracestate` opens up rich interoperability and extensibility
-scenarios for vendors. There are defined use cases for the `tracestate` like
-positioning request in multiple distributed tracing graphs and providing
-backward compatibility with older protocols. But `tracestate` is not limited to
-this use and will drive innovations and new scenarios going forward.
+The field `tracestate` opens up rich interoperability and extensibility scenarios for vendors. There are defined use cases for the `tracestate` like positioning request in multiple distributed tracing graphs and providing backward compatibility with older protocols. But `tracestate` is not limited to this use and will drive innovations and new scenarios going forward.
 
-The opaque nature of `tracestate` introduces some tension between guarantees to
-vendors around propagating vendor-specific data with traces vs. storage and
-propagation constraints.
+The opaque nature of `tracestate` introduces some tension between guarantees to vendors around propagating vendor-specific data with traces vs. storage and propagation constraints.
 
-On the one hand, field value should be small so implementors can satisfy the
-requirement to pass the value all the time. It is especially critical for
-various messaging systems where metadata like `tracestate` is not paid for by
-the customer and provided for free.
+On the one hand, field value should be small so implementors can satisfy the requirement to pass the value all the time. It is especially critical for various messaging systems where metadata like `tracestate` is not paid for by the customer and provided for free.
 
-On the other hand, in order for the field to be useful there should be some
-guarantees that it will in fact be propagated in most of the cases.
+On the other hand, in order for the field to be useful there should be some guarantees that it will in fact be propagated in most of the cases.
 
-Without changing definition of `tracestate` to make it less opaque, any declared
-limit will be arbitrary. It may be based on discussions with vendors on their
-needs. But it's still arbitrary as - first, it may not account for the needs of
-everybody and second - whatever guarantee will be provided - it will be abused
-as guaranteed propagation is a very tempting and hard to implement feature.
+Without changing definition of `tracestate` to make it less opaque, any declared limit will be arbitrary. It may be based on discussions with vendors on their needs. But it's still arbitrary as - first, it may not account for the needs of everybody and second - whatever guarantee will be provided - it will be abused as guaranteed propagation is a very tempting and hard to implement feature.
 
-Talking about abuse - one thing this working group is doing is working on
-user-defined context propagation as part of [Correlation
-Context](https://w3c.github.io/correlation-context/) spec. Correlation context
-will provide a relieve valve for people who want to have freedom propagating
-relatively big payload across the components of a distributed trace.
+Talking about abuse - one thing this working group is doing is working on user-defined context propagation as part of [Correlation Context](https://w3c.github.io/correlation-context/) spec. Correlation context will provide a relieve valve for people who want to have freedom propagating relatively big payload across the components of a distributed trace.
 
-This specification allows removing and adding as many `tracestate` entries as an
-implementation needs. This freedom is required to satisfy privacy and
-interoperability concerns. Thus all suggestions specification is making
-regarding the size of `tracestate` field will only be a recommendation that
-would improve vendors interoperability and cannot be "enforced" in practice.
+This specification allows removing and adding as many `tracestate` entries as an implementation needs. This freedom is required to satisfy privacy and interoperability concerns. Thus all suggestions specification is making regarding the size of `tracestate` field will only be a recommendation that would improve vendors interoperability and cannot be "enforced" in practice.
 
 Three solutions to address this problem were discussed:
 
 1. Declare the arbitrary max length that HAVE TO be propagated.
-2. Limit based on number of entries, not the size. Declare arbitrary minimum
-   number of entries required for propagation.
-3. Make max length the decision of the implementor. Suggest arbitrary max length
-   in specification that implementors SHOULD propagate.
+2. Limit based on number of entries, not the size. Declare arbitrary minimum number of entries required for propagation.
+3. Make max length the decision of the implementor. Suggest arbitrary max length in specification that implementors SHOULD propagate.
 
 These solutions has the following pros and cons.
 
 #### 1. Declare the arbitrary max length
 
-This is simplest and easy to understand solution. Proposals for the limit varied
-from `20` (size of a single `parent-id` with small identifier) to `1024` to fit
-up to 5 vendors with large tracestate entries. `512` is a nice median length.
+This is simplest and easy to understand solution. Proposals for the limit varied from `20` (size of a single `parent-id` with small identifier) to `1024` to fit up to 5 vendors with large tracestate entries. `512` is a nice median length.
 
-Extremely small proposal like `64` wasn't received well by vendors, while larger
-limits was unacceptable/undesirable for cloud vendors as costs of implementing
-it are quite high.
+Extremely small proposal like `64` wasn't received well by vendors, while larger limits was unacceptable/undesirable for cloud vendors as costs of implementing it are quite high.
 
 We failed to find a number everybody liked.
 
 #### 2. Limit based on number of entries
 
-This proposal was made to eliminate the problem of a "greedy" vendor utilizes
-the full length of a `tracestate` and ultimately blocking the interoperability.
+This proposal was made to eliminate the problem of a "greedy" vendor utilizes the full length of a `tracestate` and ultimately blocking the interoperability.
 
-Problem with this proposal is that limits proposed for the individual entry
-(e.g. `128`) were still quite high for cloud providers.
+Problem with this proposal is that limits proposed for the individual entry (e.g. `128`) were still quite high for cloud providers.
 
-Also even though seemingly this proposal makes interoperability better, abuse of
-using multiple entries by a single vendor is still unavoidable.
+Also even though seemingly this proposal makes interoperability better, abuse of using multiple entries by a single vendor is still unavoidable.
 
-Good way to discourage vendors to use long `tracestate` values is to suggest to
-remove those first when limit was reached.
+Good way to discourage vendors to use long `tracestate` values is to suggest to remove those first when limit was reached.
 
 #### 3. Make max length the decision of the implementor
 
-Options above "protected" vendors from implementors who will take optional
-nature of `tracestate` and will not propagate `tracestate`. However the reality
-is that for many platforms even larger `tracestate` fields propagation is not a
-concern.
+Options above "protected" vendors from implementors who will take optional nature of `tracestate` and will not propagate `tracestate`. However the reality is that for many platforms even larger `tracestate` fields propagation is not a concern.
 
-So there was a proposal that the spec will suggest the length limits, and define
-the algorithm of trimming `tracestate`. However the final decision of an actual
-implementation to the platform.
+So there was a proposal that the spec will suggest the length limits, and define the algorithm of trimming `tracestate`. However the final decision of an actual implementation to the platform.
 
-One of the side effects of this proposal is that it encourages tracing vendors
-to minimize the use of `tracestate` for non-essential scenarios to ensure
-propagation of an essential fields. Which is aligned with the spirit of
-`tracestate`.
+One of the side effects of this proposal is that it encourages tracing vendors to minimize the use of `tracestate` for non-essential scenarios to ensure propagation of an essential fields. Which is aligned with the spirit of `tracestate`.
 
-One addition to this scenario was made to discourage people using `tracestate`
-values of size larger than `128` long. Specification suggests to cut those
-entries first.
+One addition to this scenario was made to discourage people using `tracestate` values of size larger than `128` long. Specification suggests to cut those entries first.
 
 ### Maximum number of elements
 
 Here are some rationals and assumptions:
 
-- the total size can be calculated 2 * num_elements - 1 (delimiters) +
-  sum(key.size()) + sum(value.size()).
-- we assume that each key will have around 4 elements (e.g. `msft`, `goog`,
-  etc).
+- the total size can be calculated 2 * num_elements - 1 (delimiters) + sum(key.size()) + sum(value.size()).
+- we assume that each key will have around 4 elements (e.g. `msft`, `goog`, etc).
 - we assume that each value will have 8 or more characters (e.g. one hex int32).
-- based on the previous two assumptions each key-value pair will have more than
-  12 characters.
+- based on the previous two assumptions each key-value pair will have more than 12 characters.
 
-Based on these assumptions and rationals a maximum number of elements of 32
-looks like a reasonable compromise.
+Based on these assumptions and rationals a maximum number of elements of 32 looks like a reasonable compromise.
 
 ## Forcing lower case tracestate names
 
 Lowercase names have a few benefits:
-- consistent with structured headers specification
-  http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html
-- make naming consistent and avoid potential interoperability issues between
-  systems
+- consistent with structured headers specification http://httpwg.org/http-extensions/draft-ietf-httpbis-header-structure.html
+- make naming consistent and avoid potential interoperability issues between systems
 - encourages minimizing the name size to a single word
 
 ## String encoding of names
 
-Url encoding is low-overhead way to encode unicode characters for non-latin
-characters in the values. Url encoding keeps a single words in latin unchanged
-and easily readable.
+Url encoding is low-overhead way to encode unicode characters for non-latin characters in the values. Url encoding keeps a single words in latin unchanged and easily readable.
 
 ## Vendor name in a key
 
-Sign `@` is allowed in a key for easy parsing of vendor name out of the
-tracestate key. The idea is that with the registry of trace vendors one can
-easily understand the vendor name and how to parse it's trace state. Without `@`
-sign parsing will be more complicated. Also `@` sign has known semantics in
-addressing for protocols like ftp and e-mails.
+Sign `@` is allowed in a key for easy parsing of vendor name out of the tracestate key. The idea is that with the registry of trace vendors one can easily understand the vendor name and how to parse it's trace state. Without `@` sign parsing will be more complicated. Also `@` sign has known semantics in addressing for protocols like ftp and e-mails.
 
 ## Versioning
 
@@ -243,92 +124,44 @@ Versioning options are:
 2. Re-start trace when you see unknown header
 3. Try to parse trace following some rules when you see unknown header
 
-One variation is whether original or new header that you cannot recognize is
-preserved in `tracestate`.
+One variation is whether original or new header that you cannot recognize is preserved in `tracestate`.
 
-- Option 1 is least favorable as it makes one bad header break the entire
-  <a>distributed trace</a>.
-- Option 2 is better. It's easy, doesn't restrict future version in any way and
-  re-started trace should be understood by new systems. So only one "connection"
-  is lost. And the lost connection issue can be solved by storing the original
-  header in `tracestate`. Drawbacks are also obvious. First, single old
-  component always breaks traces. Second, it's harder to transition without
-  customer disatisfaction of broken traces. 
+- Option 1 is least favorable as it makes one bad header break the entire <a>distributed trace</a>.
+- Option 2 is better. It's easy, doesn't restrict future version in any way and re-started trace should be understood by new systems. So only one "connection" is lost. And the lost connection issue can be solved by storing the original header in `tracestate`. Drawbacks are also obvious. First, single old component always breaks traces. Second, it's harder to transition without customer disatisfaction of broken traces.
 
-  Storing original value also has negative effects. Valid `traceparent` is 55
-  characters (out of 512 allowed for `tracestate`). And "bad" headers could be
-  much longer pushing valuable `tracestate` pairs out. Also this requirement
-  increases the chance of abuse. When a bad actor will start sending a header
-  with the version `99` that is only understood by that actor. And the fact that
-  every system passes thru the original value allows this actor to build a
-  complete solution based on this header.
-- Option 3 with the fallback to option 2 seems to allow the easiest transition
-  between versions by forcing a lot of restrictions on the future. Initial
-  proposal was to try to parse individual parts like `trace-id` than
-  `parent-id`. Assuming `parent-id` size or format may change without changing
-  `trace-id`. However the majority sees potential for abuse here. So we suggest
-  to force future versions to be additive to the current format. And if parsing
-  fails at any stage - simply restart the trace.
+  Storing original value also has negative effects. Valid `traceparent` is 55 characters (out of 512 allowed for `tracestate`). And "bad" headers could be much longer pushing valuable `tracestate` pairs out. Also this requirement increases the chance of abuse. When a bad actor will start sending a header with the version `99` that is only understood by that actor. And the fact that every system passes thru the original value allows this actor to build a complete solution based on this header.
+- Option 3 with the fallback to option 2 seems to allow the easiest transition between versions by forcing a lot of restrictions on the future. Initial proposal was to try to parse individual parts like `trace-id` than `parent-id`. Assuming `parent-id` size or format may change without changing `trace-id`. However the majority sees potential for abuse here. So we suggest to force future versions to be additive to the current format. And if parsing fails at any stage - simply restart the trace.
 
 ## Restarting trace
 
-Developers sometimes feel a need to restart a trace due to security concerns,
-however trace context should not contain information that can compromise your
-application,  and tracing vendors should work through the risks of trusting
-incoming identifiers without compromising on interoperability.
+Developers sometimes feel a need to restart a trace due to security concerns, however trace context should not contain information that can compromise your application,  and tracing vendors should work through the risks of trusting incoming identifiers without compromising on interoperability.
 
-If restarting a trace is unavoidable, you SHOULD clear the `tracestate` list as
-well. The data carried in `tracestate` carries information that often has a
-strong association with the `traceparent`, particularly `trace-id`. Tracing
-vendors will often assume that these values are associated, which is why
-`tracestate` SHOULD be cleared when `traceparent` is changed.
+If restarting a trace is unavoidable, you SHOULD clear the `tracestate` list as well. The data carried in `tracestate` carries information that often has a strong association with the `traceparent`, particularly `trace-id`. Tracing vendors will often assume that these values are associated, which is why `tracestate` SHOULD be cleared when `traceparent` is changed.
 
-There are scenarios, however, which may require different behavior. For example,
-if a trace was restarted when entered some secure boundaries and than restored
-back when it is leaving those boundaries - keeping the original `tracestate`
-entries will fully restore the trace back to normal. In this example,
-vendor-specific context will be propagated through these secure boundaries.
+There are scenarios, however, which may require different behavior. For example, if a trace was restarted when entered some secure boundaries and than restored back when it is leaving those boundaries - keeping the original `tracestate` entries will fully restore the trace back to normal. In this example, vendor-specific context will be propagated through these secure boundaries.
 
-Scenarios like the one above require careful coding and understanding of what
-they are trying to achieve, and should be considered an exception.
-Implementations should discourage this type of restarts. For example,
-implementations may allow this scenario only by means of restarting the trace
-WITH `tracestate` clean up and than re-population of `tracestate` can only be
-implemented as an explicit copy/pasting of `tracestate` entries one by one.
+Scenarios like the one above require careful coding and understanding of what they are trying to achieve, and should be considered an exception. Implementations should discourage this type of restarts. For example, implementations may allow this scenario only by means of restarting the trace WITH `tracestate` clean up and than re-population of `tracestate` can only be implemented as an explicit copy/pasting of `tracestate` entries one by one.
 
 ## Response headers
 
-**TL;DR;** There are many scenarios where collaboration between distributed
-tracing vendors require writing and reading response headers. We can see that
-this can have value, but don't think right now is the right time to standardize.
-We decided we would rather wait for individual vendors to start to collaborate
-over response headers and later decide which scenarios are worth standardizing.
-Use of `traceparent` and `tracestate` headers is not forbidden in response
-headers.
+**TL;DR;** There are many scenarios where collaboration between distributed tracing vendors require writing and reading response headers. We can see that this can have value, but don't think right now is the right time to standardize. We decided we would rather wait for individual vendors to start to collaborate over response headers and later decide which scenarios are worth standardizing. Use of `traceparent` and `tracestate` headers is not forbidden in response headers.
 
 ### Use Cases
 
 1. Restart a trace and return new trace identification information to caller.
-2. Send Tenant ID/identity of the service so caller knows where to query
-   telemetry from.
-3. Notify upstream to sample trace sending a sampling flag (+ sampling score)
-   for delegated sampling.
-4. Report back data to the caller (like server timing, method name, application
-   type and version). E.g. for HTTP call - caller only knows the url when server
-   knows route information. Route information may be helpful to caller to group
-   outgoing requests.
+2. Send Tenant ID/identity of the service so caller knows where to query telemetry from.
+3. Notify upstream to sample trace sending a sampling flag (+ sampling score) for delegated sampling.
+4. Report back data to the caller (like server timing, method name, application type and version). E.g. for HTTP call - caller only knows the url when server knows route information. Route information may be helpful to caller to group outgoing requests.
 
 ### Open Issues
 
 - If standard defines response headers - are they required or optional?
-- How are they propagated to the caller of the caller? Is this done via multiple
-  hops?
+- How are they propagated to the caller of the caller? Is this done via multiple hops?
 - Some IoT devices may not expect relatively large response headers.
 
 ### Potential Content of a Header
 
-- `traceparent` can be used for use cases 1 and 3 (identity and deferred
-  sampling).
+- `traceparent` can be used for use cases 1 and 3 (identity and deferred sampling).
 - `tracestate`-like header can be used for all use cases.
 
 ### Problems

--- a/spec/30-processing-model.md
+++ b/spec/30-processing-model.md
@@ -1,61 +1,29 @@
 # Processing Model
 
-This section provides a step-by-step exemplary description of the behavior of a tracing
-implementation - also called tracer - when a request is received, processed and
-potentially forwarded. This description can be used as a reference when
-implementing a Trace Context compliant tracing system, middleware - like a proxy
-or messaging bus - or cloud service.
+This section provides a step-by-step exemplary description of the behavior of a tracing implementation - also called tracer - when a request is received, processed and potentially forwarded. This description can be used as a reference when implementing a Trace Context compliant tracing system, middleware - like a proxy or messaging bus - or cloud service.
 
 ## Processing Model for Working with Trace Context
 
-The processing model describes the behavior of a tracer which modifies and
-forwards Trace Context headers.
+The processing model describes the behavior of a tracer which modifies and forwards Trace Context headers.
 
-1. The tracer checks an incoming request for a `traceparent` and a `tracestate`
-   header.
-2. If no `traceparent` header is received, the tracer creates a new `trace-id`
-   and `parent-id` representing the current request.
-3. If `traceparent` header is present, the tracer tries to parse the version of
-   the `traceparent` header.
-    - If the version cannot be parsed, the tracer creates a new
-      `traceparent` header and deletes `tracestate`.
-    - If the version number is higher than supported by the tracer, the
-      implementation uses the format defined in this specification to parse
-      `trace-id` and `parent-id`. The tracer will only parse `trace-flags` values
-      supported by the current version of this specification and ignore all other
-      values. If parsing fails, the tracing system creates a new `traceparent`
-      header and deletes the `tracestate`.
-4. If the tracer supports the version number, it validates `trace-id` and
-   `parent-id`.
-       - If either `trace-id`, `parent-id` or `trace-flags` are invalid, the tracer
-      creates a new `traceparent` header and deletes `tracestate`.
-5. The tracer validates the `tracestate` header. If the `tracestate` header
-   cannot be parsed the tracer deletes it.
+1. The tracer checks an incoming request for a `traceparent` and a `tracestate` header.
+2. If no `traceparent` header is received, the tracer creates a new `trace-id` and `parent-id` representing the current request.
+3. If `traceparent` header is present, the tracer tries to parse the version of the `traceparent` header.
+    - If the version cannot be parsed, the tracer creates a new `traceparent` header and deletes `tracestate`.
+    - If the version number is higher than supported by the tracer, the implementation uses the format defined in this specification to parse `trace-id` and `parent-id`. The tracer will only parse `trace-flags` values supported by the current version of this specification and ignore all other values. If parsing fails, the tracing system creates a new `traceparent` header and deletes the `tracestate`.
+4. If the tracer supports the version number, it validates `trace-id` and `parent-id`.
+    - If either `trace-id`, `parent-id` or `trace-flags` are invalid, the tracer creates a new `traceparent` header and deletes `tracestate`.
+5. The tracer validates the `tracestate` header. If the `tracestate` header cannot be parsed the tracer deletes it.
 6. For each outgoing request the tracer performs the following steps:
     - The tracing system MUST modify the `traceparent` header.
-        - **Update `parent-id`**. The value of property `parent-id` MUST be set to a
-          value representing the ID of the current operation.
-        - **Update `sampled`**. The value of `sampled` reflects the caller's
-          recording behavior. The value of the `sampled` flag of `trace-flags` MAY
-          be set to `1` if the trace data is likely to be recorded or to `0`
-          otherwise. Setting the flag is no guarantee that the trace will be
-          recorded but increases the likeliness of end-to-end recorded traces.
+        - **Update `parent-id`**. The value of property `parent-id` MUST be set to a value representing the ID of the current operation.
+        - **Update `sampled`**. The value of `sampled` reflects the caller's recording behavior. The value of the `sampled` flag of `trace-flags` MAY be set to `1` if the trace data is likely to be recorded or to `0` otherwise. Setting the flag is no guarantee that the trace will be recorded but increases the likeliness of end-to-end recorded traces.
     - The tracer MAY modify the `tracestate` header
-        - **Update key value**. The value of any key can be updated. Modified keys
-            MUST be moved to the beginning of the list.
-        - **Add new key-value pair**. The new key-value pair MUST be added into
-          the beginning of the list.
-        - **Delete the key-value pair**. Any key-value pair MAY be deleted. It is
-          highly discouraged to delete keys that weren't generated by the same
-          tracing system or platform. Deletion of any key-value pair MAY
-          break correlation in other systems.
-    - The tracer sets the `traceparent` and `tracestate` header for the outgoing
-      request.
+        - **Update key value**. The value of any key can be updated. Modified keys MUST be moved to the beginning of the list.
+        - **Add new key-value pair**. The new key-value pair MUST be added into the beginning of the list.
+        - **Delete the key-value pair**. Any key-value pair MAY be deleted. It is highly discouraged to delete keys that weren't generated by the same tracing system or platform. Deletion of any key-value pair MAY break correlation in other systems.
+    - The tracer sets the `traceparent` and `tracestate` header for the outgoing request.
 
 ## Alternative Processing
 
-The processing model above describes the complete set of steps for processing
-Trace Context headers. There are, however, situations when an implementation
-might only support a subset of the steps described above. Proxies or messaging
-middleware MAY decide to not modify the `traceparent` headers but remove invalid
-headers or add additional information to `tracestate`.
+The processing model above describes the complete set of steps for processing Trace Context headers. There are, however, situations when an implementation might only support a subset of the steps described above. Proxies or messaging middleware MAY decide to not modify the `traceparent` headers but remove invalid headers or add additional information to `tracestate`.

--- a/spec/40-other-protocols.md
+++ b/spec/40-other-protocols.md
@@ -1,10 +1,5 @@
 # Other communication protocols
 
-While trace context is defined for HTTP the authors acknowledge it is also
-relevant for other communication protocols. Extensions of this specification as
-well as specifications produced by external organizations define the format of
-trace context serialization and deserialization for other protocols. Note, that
-these extensions may be at a different maturity level than this specification.
+While trace context is defined for HTTP the authors acknowledge it is also relevant for other communication protocols. Extensions of this specification as well as specifications produced by external organizations define the format of trace context serialization and deserialization for other protocols. Note, that these extensions may be at a different maturity level than this specification.
 
-Please refer to the [[!trace-context-protocols-registry]] for the details of trace context
-implementation for other protocols.
+Please refer to the [[!trace-context-protocols-registry]] for the details of trace context implementation for other protocols.

--- a/spec/50-privacy.md
+++ b/spec/50-privacy.md
@@ -1,69 +1,27 @@
 # Privacy Considerations
 
-Requirements to propagate headers to downstream services as well as storing
-values of these headers opens up potential privacy concerns. Trace vendors MUST
-NOT use `traceparent` and `tracestate` fields for any personally identifiable or
-otherwise sensitive information. The only purpose of these fields is to enable
-trace correlation.
+Requirements to propagate headers to downstream services as well as storing values of these headers opens up potential privacy concerns. Trace vendors MUST NOT use `traceparent` and `tracestate` fields for any personally identifiable or otherwise sensitive information. The only purpose of these fields is to enable trace correlation.
 
-Trace vendors MUST assess the risk of header abuse. This section provides some
-considerations and initial assessment of the risk associated with storing and
-propagating these headers. Tracing systems or platforms may choose to inspect
-and remove sensitive information from the fields before allowing the tracing
-system to execute code that potentially can propagate or store these fields. All
-mutations should, however, conform to the list of mutations defined in this
-specification.
+Trace vendors MUST assess the risk of header abuse. This section provides some considerations and initial assessment of the risk associated with storing and propagating these headers. Tracing systems or platforms may choose to inspect and remove sensitive information from the fields before allowing the tracing system to execute code that potentially can propagate or store these fields. All mutations should, however, conform to the list of mutations defined in this specification.
 
 ## Privacy of traceparent field
 
-The `traceparent` field is comprised of randomly-generated numbers. If a random
-number generator leverages any user identifiable information like IP address as
-seed state - this information may be exposed. Random number generators MUST NOT
-rely on any information that can potentially be user identifiable.
+The `traceparent` field is comprised of randomly-generated numbers. If a random number generator leverages any user identifiable information like IP address as seed state - this information may be exposed. Random number generators MUST NOT rely on any information that can potentially be user identifiable.
 
-Another privacy risk of the `traceparent` field is an ability to correlate calls
-made as part of a single transaction. A downstream service may track and
-correlate two or more calls made in a single transaction and make assumptions
-about the identity of the caller of one call based on information from another
-call.
+Another privacy risk of the `traceparent` field is an ability to correlate calls made as part of a single transaction. A downstream service may track and correlate two or more calls made in a single transaction and make assumptions about the identity of the caller of one call based on information from another call.
 
-Note, both of the mentioned privacy concerns of the `traceparent` field are
-theoretical rather than practical. Some services initiating or receiving a call
-MAY choose to restart a `traceparent` field to eliminate those risks completely.
-It is recommended to find a way to minimize the number of <a>distributed
-trace</a> restarts to promote interoperability of tracing vendors. Instead,
-different techniques may be used. For example, services may define trust
-boundaries of upstream and downstream connections and the level of exposure any
-calls may bring. For instance, only restart `traceparent` for authentication
-calls from or to external services.
+Note, both of the mentioned privacy concerns of the `traceparent` field are theoretical rather than practical. Some services initiating or receiving a call MAY choose to restart a `traceparent` field to eliminate those risks completely. It is recommended to find a way to minimize the number of <a>distributed trace</a> restarts to promote interoperability of tracing vendors. Instead, different techniques may be used. For example, services may define trust boundaries of upstream and downstream connections and the level of exposure any calls may bring. For instance, only restart `traceparent` for authentication calls from or to external services.
 
-Services may also define an algorithm and audit mechanism to validate randomness
-of incoming or outgoing random numbers in the `traceparent` field. Note, this
-algorithm will be services-specific and not a part of this specification. One
-example could be a temporal algorithm where a reversible hash function is
-applied to the current clock time. The receiver can validate that the time is
-within agreed upon boundaries, meaning the random number was generated with the
-required algorithm and in fact doesn't contain any personal identifiable
-information.
+Services may also define an algorithm and audit mechanism to validate randomness of incoming or outgoing random numbers in the `traceparent` field. Note, this algorithm will be services-specific and not a part of this specification. One example could be a temporal algorithm where a reversible hash function is applied to the current clock time. The receiver can validate that the time is within agreed upon boundaries, meaning the random number was generated with the required algorithm and in fact doesn't contain any personal identifiable information.
 
 ## Privacy of tracestate field
 
-The `tracestate` field may contain any opaque value in any of the keys. The main
-purpose of this header is to provide additional vendor-specific
-trace-identification information across different distributed tracing systems.
+The `tracestate` field may contain any opaque value in any of the keys. The main purpose of this header is to provide additional vendor-specific trace-identification information across different distributed tracing systems.
 
-Tracing systems MUST NOT include any personally identifiable information in the
-`tracestate` header.
+Tracing systems MUST NOT include any personally identifiable information in the `tracestate` header.
 
-Platforms and tracing systems extremely sensitive to personal information
-exposure MAY implement selective removal of values corresponding to the unknown
-keys. This mutation of the `tracestate` field is not forbidden, but highly
-discouraged. As it defeats the purpose of this field for allowing multiple
-tracing systems to collaborate.
+Platforms and tracing systems extremely sensitive to personal information exposure MAY implement selective removal of values corresponding to the unknown keys. This mutation of the `tracestate` field is not forbidden, but highly discouraged. As it defeats the purpose of this field for allowing multiple tracing systems to collaborate.
 
 ## Other risks
 
-In implementations where `traceparent` and `tracestate` headers are included in
-responses, these values may inadvertently be passed to cross-origin callers.
-Implementations should ensure that they only include these response headers when
-responding to systems that participated in the trace.
+In implementations where `traceparent` and `tracestate` headers are included in responses, these values may inadvertently be passed to cross-origin callers. Implementations should ensure that they only include these response headers when responding to systems that participated in the trace.

--- a/spec/51-security.md
+++ b/spec/51-security.md
@@ -1,49 +1,23 @@
 # Security Considerations
 
-There are two types of potential security risks associated with this
-specification: information exposure and denial of service attacks against the
-tracing system.
+There are two types of potential security risks associated with this specification: information exposure and denial of service attacks against the tracing system.
 
-Services and platforms relying on `traceparent` and `tracestate` headers should
-also follow all the best practices of parsing potentially malicious headers.
-Including checking for header length and content of header values. These
-practices help to avoid buffer overflow and html injection attacks.
+Services and platforms relying on `traceparent` and `tracestate` headers should also follow all the best practices of parsing potentially malicious headers. Including checking for header length and content of header values. These practices help to avoid buffer overflow and html injection attacks.
 
 ## Information exposure
 
-As mentioned in the privacy section, information in `traceparent` and
-`tracestate` headers may carry information that can be considered sensitive. For
-example, `traceparent` may allow one call to be correlated to the data sent with
-another call. `tracestate` may imply the version of monitoring software used by
-the caller. This information could potentially be used to create a larger
-attack.
+As mentioned in the privacy section, information in `traceparent` and `tracestate` headers may carry information that can be considered sensitive. For example, `traceparent` may allow one call to be correlated to the data sent with another call. `tracestate` may imply the version of monitoring software used by the caller. This information could potentially be used to create a larger attack.
 
-Application owners should either ensure that no proprietary or confidential
-information is stored in the `tracestate`, or they should ensure that
-`tracestate` isn't present in requests to external systems.
+Application owners should either ensure that no proprietary or confidential information is stored in the `tracestate`, or they should ensure that `tracestate` isn't present in requests to external systems.
 
 ## Denial of service
 
-When distributed tracing is enabled on a service with a public API and naively
-continues any trace with the `sampled` flag set, a malicious attacker could
-overwhelm an application with tracing overhead, forge `trace-id` collisions that
-make monitoring data unusable, or run up your tracing bill with your SaaS
-tracing vendor.
+When distributed tracing is enabled on a service with a public API and naively continues any trace with the `sampled` flag set, a malicious attacker could overwhelm an application with tracing overhead, forge `trace-id` collisions that make monitoring data unusable, or run up your tracing bill with your SaaS tracing vendor.
 
-Tracing vendors and platforms should account for these situations and make sure
-that checks and balances are in place to protect denial of monitoring by
-malicious or badly authored callers.
+Tracing vendors and platforms should account for these situations and make sure that checks and balances are in place to protect denial of monitoring by malicious or badly authored callers.
 
-One examples of such protection may be different tracing behavior for
-authenticated and unauthenticated requests. Various rate limiters for data
-recording can also be implemented.
+One examples of such protection may be different tracing behavior for authenticated and unauthenticated requests. Various rate limiters for data recording can also be implemented.
 
 ## Other risks
 
-Application owners need to make sure to test all code paths leading to the
-sending of `traceparent` and `tracestate` headers. For example, in single page
-browser applications it is typical to make cross-origin calls. If one of these
-code path leads to the sending of `traceparent` and `tracestate` headers -
-cross-origin calls restricted via <a
-data-cite='FETCH#http-access-control-request-headers'>`Access-Control-Allow-Headers`</a>
-[[FETCH]], it may fail.
+Application owners need to make sure to test all code paths leading to the sending of `traceparent` and `tracestate` headers. For example, in single page browser applications it is typical to make cross-origin calls. If one of these code path leads to the sending of `traceparent` and `tracestate` headers - cross-origin calls restricted via <a data-cite='FETCH#http-access-control-request-headers'>`Access-Control-Allow-Headers`</a> [[FETCH]], it may fail.

--- a/spec/60-acknowledgments.md
+++ b/spec/60-acknowledgments.md
@@ -1,5 +1,3 @@
 ## Acknowledgments
 
-Thanks to Adrian Cole, Christoph Neumüller, Daniel Khan, Erika Arnold, Fabian
-Lange, Matthew Wear, Reiley Yang, Ted Young, Tyler Benson, Victor Soares for
-their contributions to this work.
+Thanks to Adrian Cole, Christoph Neumüller, Daniel Khan, Erika Arnold, Fabian Lange, Matthew Wear, Reiley Yang, Ted Young, Tyler Benson, Victor Soares for their contributions to this work.


### PR DESCRIPTION
[Discussed during today's meeting. We decided to split this commit from #307 out into its own PR]

Hard line breaks are unnecessary for correctly displaying Markdown, but make editing very difficult.