### PR TITLE
Fix respec rendering

### DIFF
--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -72,8 +72,9 @@ This section uses the Augmented Backus-Naur Form (ABNF) notation of [[RFC5234](h
 
 ``` abnf
 HEXDIGLC = DIGIT / "a" / "b" / "c" / "d" / "e" / "f" ; lowercase hex character
-
 value           = version "-" version-format
+```
+
 The dash (`-`) character is used as a delimiter between fields.
 
 #### version


### PR DESCRIPTION
After merging #307 the html rendering of the spec was broken as a result of missing closing ``` under the `traceparent Header Field Values` section. This PR fixes that issue.

Before:
<img width="818" alt="Screen Shot 2019-07-16 at 12 40 14 PM" src="https://user-images.githubusercontent.com/2513372/61324480-6537d880-a7c7-11e9-8558-1b154d69199b.png">

After:
<img width="818" alt="Screen Shot 2019-07-16 at 12 40 21 PM" src="https://user-images.githubusercontent.com/2513372/61324506-741e8b00-a7c7-11e9-841a-9ef71945f1c3.png">

