### PR TITLE
Remove non-normative duplication

### DIFF
--- a/spec/30-processing-model.md
+++ b/spec/30-processing-model.md
@@ -1,7 +1,5 @@
 # Processing Model
 
-_This section is non-normative._
-
 This section provides a step-by-step example of a tracing vendor receiving a request with trace context headers, processing the request and then potentially forwarding it. This description can be used as a reference when implementing a trace context-compliant tracing system, middleware (like a proxy or messaging bus), or a cloud service.
 
 ## Processing Model for Working with Trace Context


### PR DESCRIPTION
Respec automatically inserts "This section is non-normative" for sections with the css class "informative". Explicity stating this in the spec resulted in duplicate non-normative statements. This PR removes the explicit statement from the spec. 

**Before**
![Screen Shot 2019-07-17 at 3 21 33 PM](https://user-images.githubusercontent.com/2513372/61416230-e070bb80-a8a7-11e9-9470-9444a342f121.png)

**After**
![Screen Shot 2019-07-17 at 3 28 08 PM](https://user-images.githubusercontent.com/2513372/61416259-f3838b80-a8a7-11e9-9bac-85d9b8b37bda.png)
