### PR TITLE
Relax tenant id format

### DIFF
--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -277,13 +277,13 @@ The key is an identifier that describes the vendor.
 
 ``` abnf
 key = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
-key = lcalpha 0*240( lcalpha / DIGIT / "_" / "-"/ "*" / "/" ) "@" lcalpha 0*13( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
+key = ( lcalpha / DIGIT ) 0*240( lcalpha / DIGIT / "_" / "-"/ "*" / "/" ) "@" lcalpha 0*13( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
 lcalpha    = %x61-7A ; a-z
 ```
 
-**Note**: Identifiers MUST begin with a lowercase letter, and can only contain lowercase letters (`a`-`z`), digits (`0`-`9`), underscores (`_`), dashes (`-`), asterisks (`*`), and forward slashes (`/`).
+**Note**: Identifiers MUST begin with a lowercase letter or a digit, and can only contain lowercase letters (`a`-`z`), digits (`0`-`9`), underscores (`_`), dashes (`-`), asterisks (`*`), and forward slashes (`/`).
 
-For multi-tenant vendors scenarios, an at sign (`@`) sign can be used to prefix the vendor name. Vendors SHOULD set the tenant ID at the beginning of the key. For example, \
+For multi-tenant vendor scenarios, an at sign (`@`) can be used to prefix the vendor name. Vendors SHOULD set the tenant ID at the beginning of the key. For example, \
 `fw529a3039@dt` - `fw529a3039` is a tenant ID and `@dt` is a vendor name. Searching for `@dt=` is more robust for parsing (for example, searching for all a vendor's keys).
 
 ##### Value


### PR DESCRIPTION
This PR relaxes the tenant id format so that it can begin with a lowercase letter or number. Previously, it was required to start with a lowercase letter. This change was discussed in issue #316.

My BNF-fu might not be quite up to snuff, so please double check it and let me know if it needs any adjustments.