### PR TITLE
Clarify behavior when receiving a tracestate header without traceparent

### DIFF
--- a/spec/30-processing-model.md
+++ b/spec/30-processing-model.md
@@ -12,8 +12,9 @@ If no traceparent header is received:
 
 1. The vendor checks an incoming request for a `traceparent` and a `tracestate` header.
 2. If _no_ `traceparent` header is received, the vendor creates a new `trace-id` and `parent-id` that represents the current request.
-3. The vendor SHOULD modify the `tracestate` header by adding a new key/value pair.
-4. The vendor sets the `traceparent` and `tracestate` header for the outgoing request.
+3. If a `tracestate` header is received without an accompanying `traceparent` header, it is invalid and MUST be discarded.
+4. The vendor SHOULD create a new `tracestate` header and add a new key/value pair.
+5. The vendor sets the `traceparent` and `tracestate` header for the outgoing request.
 
 ## A traceparent is Received
 


### PR DESCRIPTION
I believe there is an issue with the the processing model as it is currently written. The spec says:

> Every tracing tool MUST properly set traceparent even when it only relies on vendor-specific information in tracestate

Therefore, receiving a `tracestate` header without a `traceparent` should be an invalid case.

The [No traceparent Received](https://w3c.github.io/trace-context/#no-traceparent-received) section can be interpreted such that a tracing system that receives a `tracestate` header without an accompanying `traceparent` header should append to and propagate that `tracestate`. This commit clarifies that a `tracestate` header received without a `traceparent` header is invalid. The received `tracestate` header should be discarded and a new `tracestate` should be created.

There's a chance I'm mistaken. If am, perhaps we could find a way to clarify this situation further in the spec.