### PR TITLE
moved content about trace-id into informative section as a first step…

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,8 @@
   <section data-include="spec/50-privacy.md" data-include-format='markdown'></section>
   <section data-include="spec/51-security.md" data-include-format='markdown'></section>
 
+  <section class="informative" data-include="spec/60-trace-id-format.md" data-include-format='markdown'></section>
+
   <section class="appendix" data-include="spec/60-acknowledgments.md" data-include-format='markdown'></section>
 
   <section class="informative">

--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -102,16 +102,11 @@ trace-flags      = 2HEXDIGLC   ; 8 bit flags. Currently, only one bit is used. S
 
 This is the ID of the whole trace forest and is used to uniquely identify a [distributed trace](https://w3c.github.io/trace-context/#dfn-distributed-traces) through a system. It is represented as a 16-byte array, for example, `4bf92f3577b34da6a3ce929d0e0e4736`. All bytes as zero (`00000000000000000000000000000000`) is considered an invalid value.
 
-
-A vendor SHOULD generate globally unique values for `trace-id`. Many unique identification generation algorithms create IDs where one part of the value is constant (often time- or host-based), and the other part is a randomly generated value. Because tracing systems may make sampling decisions based on the value of `trace-id`, for increased interoperability vendors MUST keep the random part of `trace-id` ID on the left side.
-
-
-When a system operates with a `trace-id` that is shorter than 16 bytes, it SHOULD fill-in the extra bytes with random values rather than zeroes. Let's say the system works with an 8-byte `trace-id` like `3ce929d0e0e4736`. Instead of setting `trace-id` value to `0000000000000003ce929d0e0e4736` it SHOULD generate a value like `4bf92f3577b34da6a3ce929d0e0e4736` where `4bf92f3577b34da6a` is a random value or a function of time and host value.
-
-
-**Note**: Even though a system may operate with a shorter `trace-id` for [distributed trace](https://w3c.github.io/trace-context/#dfn-distributed-traces) reporting, the full `trace-id` MUST be propagated to conform to the specification.
-
 If the `trace-id` value is invalid (for example if it contains non-allowed characters or all zeros), vendors MUST ignore the `traceparent`.
+
+See [considerations for trace-id field
+generation](#considerations-for-trace-id-field-generation) for recommendations
+on how to operate with `trace-id`.
 
 ##### parent-id
 

--- a/spec/60-trace-id-format.md
+++ b/spec/60-trace-id-format.md
@@ -1,0 +1,20 @@
+## Considerations for trace-id field generation
+
+A vendor SHOULD generate globally unique values for `trace-id`. Many unique
+identification generation algorithms create IDs where one part of the value is
+constant (often time- or host-based), and the other part is a randomly generated
+value. Because tracing systems may make sampling decisions based on the value of
+`trace-id`, for increased interoperability vendors MUST keep the random part of
+`trace-id` ID on the left side.
+
+When a system operates with a `trace-id` that is shorter than 16 bytes, it
+SHOULD fill-in the extra bytes with random values rather than zeroes. Let's say
+the system works with an 8-byte `trace-id` like `3ce929d0e0e4736`. Instead of
+setting `trace-id` value to `0000000000000003ce929d0e0e4736` it SHOULD generate
+a value like `4bf92f3577b34da6a3ce929d0e0e4736` where `4bf92f3577b34da6a` is a
+random value or a function of time and host value.
+
+**Note**: Even though a system may operate with a shorter `trace-id` for
+[distributed trace](https://w3c.github.io/trace-context/#dfn-distributed-traces)
+reporting, the full `trace-id` MUST be propagated to conform to the
+specification.


### PR DESCRIPTION
… of addressing larger feedback on operating 64bit systems

As a first step fixing #349 the entire note about the behavior of `trace-id` was moved to informative section. The reason for this move is to enable us writing recommendation freely even if they break formal requirement of propagating entire `trace-id`. This will enable us to explain better how 64bit systems should operate for better inter-oprability avoiding the demand to re-start the entire `trace-id` every time.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 3, 2019, 6:33 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Ftrace-context%2Fa80774c4072eb86cf87a4a2df5a224f7ab3ca527%2Findex.html%3FisPreview%3Dtrue)

```
[33m📡 HTTP Error 520:[39m [36mhttps://rawcdn.githack.com/w3c/trace-context/a80774c4072eb86cf87a4a2df5a224f7ab3ca527/index.html[39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/trace-context%23351.)._
</details>
