### PR TITLE
Remove preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,11 +6,11 @@
   <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove' defer></script>
   <script class='remove'>
     var respecConfig = {
-      specStatus: "CR",
+      specStatus: "ED",
       implementationReportURI: "https://github.com/w3c/trace-context/#reference-implementations",
-      previousMaturity: "WD",
-      previousPublishDate : "2018-11-22",
-      crEnd: "2019-10-08",
+      /* previousMaturity: "CR",
+      previousPublishDate : "2019-08-13",
+      crEnd: "2019-10-08",*/
       editors: [{
         name: "Sergey Kanzhelev",
         company: "Microsoft",

--- a/index.html
+++ b/index.html
@@ -57,7 +57,6 @@
       wg: "Distributed Tracing Working Group",
       wgPublicList: "public-trace-context",
       wgURI: "https://www.w3.org/2018/distributed-tracing/",
-      isPreview: true, //this will add ugly box saying it's preview
       otherLinks: [{
         key: 'Discussions',
         data: [{


### PR DESCRIPTION
This addresses #345 
Remove the preview warning, which cannot be configured to point to something else than the editor's draft:
 https://github.com/w3c/respec/blob/develop/src/w3c/templates/sotd.js#L124

And make the document an actual editor's draft, rather than an official CR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/pull/355.html" title="Last updated on Nov 5, 2019, 7:52 PM UTC (896230a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/355/6d99f97...896230a.html" title="Last updated on Nov 5, 2019, 7:52 PM UTC (896230a)">Diff</a>