### PR TITLE
Add links to Elastic APM implementations

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -7,7 +7,13 @@ This page contains an alphabetical list of projects and vendors that currently i
 **Website:** [https://elastic.co/products/apm](https://elastic.co/products/apm)
 
 **Implementations:**
-[Node.js](https://github.com/elastic/node-traceparent).
+[.NET](https://github.com/elastic/apm-agent-dotnet/blob/700754909b1ac522796294b99adcc98063efcf42/src/Elastic.Apm/DistributedTracing/TraceParent.cs),
+[Go](),
+[Java](https://github.com/elastic/apm-agent-java/blob/e4cdde0b860ff37ea57e0ca083c62b319c0ee940/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java),
+[Node.js](https://github.com/elastic/node-traceparent),
+[Python](https://github.com/elastic/apm-agent-python/blob/50dce143ae15f6c592a70cb858a8c4721dd80ef5/elasticapm/utils/disttracing.py),
+[Ruby](https://github.com/elastic/apm-agent-ruby/blob/b68f1f12ae48a5c6e757241c65de97a98488ee6a/lib/elastic_apm/trace_context.rb),
+[JavaScript/RUM]()
 
 ## Dynatrace
 **Website:** [dynatrace.com](https://www.dynatrace.com)

--- a/implementations.md
+++ b/implementations.md
@@ -8,7 +8,7 @@ This page contains an alphabetical list of projects and vendors that currently i
 
 **Implementations:**
 [.NET](https://github.com/elastic/apm-agent-dotnet/blob/700754909b1ac522796294b99adcc98063efcf42/src/Elastic.Apm/DistributedTracing/TraceParent.cs),
-[Go](https://github.com/elastic/apm-agent-go/blob/0365ba99e57221bfa884579c69cbcc0a16c2ded7/tracecontext.go),
+[Go](https://github.com/elastic/apm-agent-go/blob/0e868bf43005f3f5b3786101960137d7c8760361/module/apmhttp/traceheaders.go),
 [Java](https://github.com/elastic/apm-agent-java/blob/e4cdde0b860ff37ea57e0ca083c62b319c0ee940/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java),
 [Node.js](https://github.com/elastic/node-traceparent),
 [Python](https://github.com/elastic/apm-agent-python/blob/50dce143ae15f6c592a70cb858a8c4721dd80ef5/elasticapm/utils/disttracing.py),

--- a/implementations.md
+++ b/implementations.md
@@ -13,7 +13,7 @@ This page contains an alphabetical list of projects and vendors that currently i
 [Node.js](https://github.com/elastic/node-traceparent),
 [Python](https://github.com/elastic/apm-agent-python/blob/50dce143ae15f6c592a70cb858a8c4721dd80ef5/elasticapm/utils/disttracing.py),
 [Ruby](https://github.com/elastic/apm-agent-ruby/blob/b68f1f12ae48a5c6e757241c65de97a98488ee6a/lib/elastic_apm/trace_context.rb),
-[JavaScript/RUM]()
+[JavaScript - Real User Monitoring](https://github.com/elastic/apm-agent-rum-js)
 
 ## Dynatrace
 **Website:** [dynatrace.com](https://www.dynatrace.com)

--- a/implementations.md
+++ b/implementations.md
@@ -8,7 +8,7 @@ This page contains an alphabetical list of projects and vendors that currently i
 
 **Implementations:**
 [.NET](https://github.com/elastic/apm-agent-dotnet/blob/700754909b1ac522796294b99adcc98063efcf42/src/Elastic.Apm/DistributedTracing/TraceParent.cs),
-[Go](),
+[Go](https://github.com/elastic/apm-agent-go/blob/0365ba99e57221bfa884579c69cbcc0a16c2ded7/tracecontext.go),
 [Java](https://github.com/elastic/apm-agent-java/blob/e4cdde0b860ff37ea57e0ca083c62b319c0ee940/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java),
 [Node.js](https://github.com/elastic/node-traceparent),
 [Python](https://github.com/elastic/apm-agent-python/blob/50dce143ae15f6c592a70cb858a8c4721dd80ef5/elasticapm/utils/disttracing.py),


### PR DESCRIPTION
Some links are still missing, so this is currently just a draft.

Is the best practice to have permalinks to the currently most recent version?