### PR TITLE
Clarifies the ABNF on tracestate keys

### DIFF
--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -278,7 +278,7 @@ keychar    = lcalpha / DIGIT / "_" / "-"/ "*" / "/" / "@"
 lcalpha    = %x61-7A ; a-z
 ```
 
-A `key` MUST begin with a lowercase letter and contain up to 256 characters including lowercase letters (`a`-`z`), digits (`0`-`9`), underscores (`_`), dashes (`-`), asterisks (`*`), forward slashes (`/`), and at signs (`@`).
+A `key` MUST begin with a lowercase letter or a digit and contain up to 256 characters including lowercase letters (`a`-`z`), digits (`0`-`9`), underscores (`_`), dashes (`-`), asterisks (`*`), forward slashes (`/`), and at signs (`@`).
 
 ##### Value
 

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -272,7 +272,6 @@ A `list-member` contains a key/value pair.
 
 The key is an identifier that describes the vendor.
 
-
 ``` abnf
 key = lcalpha 0*255( keychar )
 keychar    = lcalpha / DIGIT / "_" / "-"/ "*" / "/" / "@"

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -270,31 +270,16 @@ A `list-member` contains a key/value pair.
 
 ##### Key
 
-The key is an identifier that describes the vendor. There are two formats allowed, Basic and Tenant format. Both have a maximum length of 256 characters.
+The key is an identifier that describes the vendor.
 
 
 ``` abnf
-basic-key = lcalpha 0*255( keychar )
-tenant-key = ( lcalpha / DIGIT ) 0*240( keychar ) "@" lcalpha 0*13( keychar )
-keychar    = lcalpha / DIGIT / "_" / "-"/ "*" / "/"
+key = lcalpha 0*255( keychar )
+keychar    = lcalpha / DIGIT / "_" / "-"/ "*" / "/" / "@"
 lcalpha    = %x61-7A ; a-z
 ```
 
-###### Basic format
-
-Basic format MUST begin with a lowercase letter and contain lowercase letters (`a`-`z`), digits (`0`-`9`), underscores (`_`), dashes (`-`), asterisks (`*`), and forward slashes (`/`).
-
-###### Tenant format
-
-Tenant format uses an at sign (`@`) to separate a tenant ID from a vendor name. For example, the key `fw529a3039@dt` implies a tenant ID `fw529a3039` and vendor name `dt`.
-
-Tenant format MUST contain a single at sign (`@`). Characters before and after the at sign (`@`) MUST be defined in the Basic format. The up to 241 characters before the at sign (`@`) MUST begin with a lowercase letter or number. The up to 14 characters after the sign (`@`) MUST begin with a lowercase letter.
-
-Vendors SHOULD consider characters before the at sign (`@`) the tenant ID and characters after, the vendor name. Otherwise, a valid tenant ID in one system could be mistaken for the vendor name of another, leading to misinterpretation.
-
-This format was designed to ease locating all keys from the same vendor. For example, the vendor `dt` could use the index of `@dt=` to locate multiple values corresponding to tenants in their system.
-
-Note: The vendor name in Tenant format is the same as Basic format, except it is shorter (maximum 14 instead of 256 characters).
+A `key` MUST begin with a lowercase letter and contain up to 256 characters including lowercase letters (`a`-`z`), digits (`0`-`9`), underscores (`_`), dashes (`-`), asterisks (`*`), forward slashes (`/`), and at signs (`@`).
 
 ##### Value
 

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -270,18 +270,31 @@ A `list-member` contains a key/value pair.
 
 ##### Key
 
-The key is an identifier that describes the vendor.
+The key is an identifier that describes the vendor. There are two formats allowed, Basic and Tenant format. Both have a maximum length of 256 characters.
+
 
 ``` abnf
-key = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
-key = ( lcalpha / DIGIT ) 0*240( lcalpha / DIGIT / "_" / "-"/ "*" / "/" ) "@" lcalpha 0*13( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
+basic-key = lcalpha 0*255( keychar )
+tenant-key = ( lcalpha / DIGIT ) 0*240( keychar ) "@" lcalpha 0*13( keychar )
+keychar    = lcalpha / DIGIT / "_" / "-"/ "*" / "/"
 lcalpha    = %x61-7A ; a-z
 ```
 
-**Note**: Identifiers MUST begin with a lowercase letter or a digit, and can only contain lowercase letters (`a`-`z`), digits (`0`-`9`), underscores (`_`), dashes (`-`), asterisks (`*`), and forward slashes (`/`).
+###### Basic format
 
-For multi-tenant vendor scenarios, an at sign (`@`) can be used to prefix the vendor name. Vendors SHOULD set the tenant ID at the beginning of the key. For example, \
-`fw529a3039@dt` - `fw529a3039` is a tenant ID and `@dt` is a vendor name. Searching for `@dt=` is more robust for parsing (for example, searching for all a vendor's keys).
+Basic format MUST begin with a lowercase letter and contain lowercase letters (`a`-`z`), digits (`0`-`9`), underscores (`_`), dashes (`-`), asterisks (`*`), and forward slashes (`/`).
+
+
+###### Tenant format
+
+Tenant format MUST begin with a lowercase letter or number and contain a single at sign `@`. The maximum 240 characters before and maximum 13 characters after the at sign `@` MUST only be those defined in the Basic format.
+
+Tenant format is different than basic because it uses an at sign (`@`) to separate a tenant ID from the vendor name. 
+For example, the key `fw529a3039@dt` implies a tenant ID `fw529a3039` and vendor name `dt`.
+
+Vendors SHOULD consider characters before the at sign (`@`) the tenant ID and characters after, the vendor name. Otherwise, a valid tenant ID in one system could be mistaken for the vendor name of another, leading to misinterpretation.
+
+This format was designed to ease locating all keys from the same vendor. For example, the vendor `dt` could use the index of `@dt=` to locate multiple values corresponding to tenants in their system.
 
 ##### Value
 

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -284,17 +284,17 @@ lcalpha    = %x61-7A ; a-z
 
 Basic format MUST begin with a lowercase letter and contain lowercase letters (`a`-`z`), digits (`0`-`9`), underscores (`_`), dashes (`-`), asterisks (`*`), and forward slashes (`/`).
 
-
 ###### Tenant format
 
-Tenant format MUST begin with a lowercase letter or number and contain a single at sign `@`. The maximum 240 characters before and maximum 13 characters after the at sign `@` MUST only be those defined in the Basic format.
+Tenant format uses an at sign (`@`) to separate a tenant ID from a vendor name. For example, the key `fw529a3039@dt` implies a tenant ID `fw529a3039` and vendor name `dt`.
 
-Tenant format is different than basic because it uses an at sign (`@`) to separate a tenant ID from the vendor name. 
-For example, the key `fw529a3039@dt` implies a tenant ID `fw529a3039` and vendor name `dt`.
+Tenant format MUST contain a single at sign (`@`). Characters before and after the at sign (`@`) MUST be defined in the Basic format. The up to 241 characters before the at sign (`@`) MUST begin with a lowercase letter or number. The up to 14 characters after the sign (`@`) MUST begin with a lowercase letter.
 
 Vendors SHOULD consider characters before the at sign (`@`) the tenant ID and characters after, the vendor name. Otherwise, a valid tenant ID in one system could be mistaken for the vendor name of another, leading to misinterpretation.
 
 This format was designed to ease locating all keys from the same vendor. For example, the vendor `dt` could use the index of `@dt=` to locate multiple values corresponding to tenants in their system.
+
+Note: The vendor name in Tenant format is the same as Basic format, except it is shorter (maximum 14 instead of 256 characters).
 
 ##### Value
 

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -273,7 +273,7 @@ A `list-member` contains a key/value pair.
 The key is an identifier that describes the vendor.
 
 ``` abnf
-key = lcalpha 0*255( keychar )
+key = ( lcalpha / DIGIT ) 0*255 ( keychar )
 keychar    = lcalpha / DIGIT / "_" / "-"/ "*" / "/" / "@"
 lcalpha    = %x61-7A ; a-z
 ```


### PR DESCRIPTION
I'm not sure if this interpretation is correct, as I'm reverse engineering it from the ABNF. I'm reverse engineering as I expect that folks reading the spec will treat ABNF authoritative vs clerical errors interpreting it.

The main thing is that the change to allow tenant format confused whether or not digits can prefix the basic format. Other changes help better explain the impact and assumptions around tenant format, for example that the intent is to reduce (but not prevent) collisions.

https://github.com/w3c/trace-context/pull/322/files#r393638103

I've allowed edits from maintainers. You may make changes to this and merge it, or close it out with derivative progress. However, I'm not likely to do a lot of revisions. The intent was to force a discussion to fix the underlying issue and I hope you do that one way or another, even if this text is not used at all.