### PR TITLE
Add Go to the list of implementations for Instana

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -27,7 +27,8 @@ This page contains an alphabetical list of projects and vendors that currently i
 **Website:** [instana.com](https://www.instana.com)
 
 **Implementations:**
-[Node.js](https://github.com/instana/nodejs-sensor)
+[Node.js](https://github.com/instana/nodejs-sensor),
+[Go](https://github.com/instana/go-sensor)
 Java
 
 


### PR DESCRIPTION
As of [v1.13.0](https://github.com/instana/go-sensor/releases/tag/v1.13.0) Instana Go sensor has full support of W3C Trace Context out-of-the-box