### PR TITLE
Clarify description of tracestate value

### DIFF
--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -282,7 +282,7 @@ A `key` MUST begin with a lowercase letter or a digit and contain up to 256 char
 
 ##### Value
 
-The value is an opaque string containing up to 256 printable ASCII [RFC0020] characters (i.e., the range 0x20 to 0x7E) except comma (,) and (=) which must end with a character which is not a space (0x20). Note that this also excludes tabs, newlines, carriage returns, etc. This effectively means that all leading spaces MUST be preserved as part of the value and all trailing spaces MUST not be preserved.
+The value is an opaque string containing up to 256 printable ASCII [RFC0020] characters (i.e., the range 0x20 to 0x7E) except comma (,) and (=) which must end with a character which is not a space (0x20). Note that this also excludes tabs, newlines, carriage returns, etc. This means that all leading spaces MUST be preserved as part of the value and all trailing spaces are considered to be optional whitespace characters not part of the value.
 
 ``` abnf
 value    = 0*255(chr) nblk-chr

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -282,7 +282,7 @@ A `key` MUST begin with a lowercase letter or a digit and contain up to 256 char
 
 ##### Value
 
-The value is an opaque string containing up to 256 printable ASCII [RFC0020] characters (i.e., the range 0x20 to 0x7E) except comma (,) and (=) which must end with a character which is not a space (0x20). Note that this also excludes tabs, newlines, carriage returns, etc. This means that all leading spaces MUST be preserved as part of the value and all trailing spaces are considered to be optional whitespace characters not part of the value. Optional whitespace MAY be excluded when propagating the header.
+The value is an opaque string containing up to 256 printable ASCII [[!RFC0020]] characters (i.e., the range 0x20 to 0x7E) except comma (,) and (=) which must end with a character which is not a space (0x20). Note that this also excludes tabs, newlines, carriage returns, etc. This means that all leading spaces MUST be preserved as part of the value and all trailing spaces are considered to be optional whitespace characters not part of the value. Optional whitespace MAY be excluded when propagating the header.
 
 ``` abnf
 value    = 0*255(chr) nblk-chr

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -282,7 +282,7 @@ A `key` MUST begin with a lowercase letter or a digit and contain up to 256 char
 
 ##### Value
 
-The value is an opaque string containing up to 256 printable ASCII [RFC0020] characters (i.e., the range 0x20 to 0x7E) except comma (,) and (=) which must end with a character which is not a space (0x20). Note that this also excludes tabs, newlines, carriage returns, etc. This means that all leading spaces MUST be preserved as part of the value and all trailing spaces are considered to be optional whitespace characters not part of the value.
+The value is an opaque string containing up to 256 printable ASCII [RFC0020] characters (i.e., the range 0x20 to 0x7E) except comma (,) and (=) which must end with a character which is not a space (0x20). Note that this also excludes tabs, newlines, carriage returns, etc. This means that all leading spaces MUST be preserved as part of the value and all trailing spaces are considered to be optional whitespace characters not part of the value. They MAY be excluded when propagating the header.
 
 ``` abnf
 value    = 0*255(chr) nblk-chr

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -282,7 +282,7 @@ A `key` MUST begin with a lowercase letter or a digit and contain up to 256 char
 
 ##### Value
 
-The value is an opaque string containing up to 256 printable ASCII [RFC0020] characters (i.e., the range 0x20 to 0x7E) except comma (,) and (=) which must end with a character which is not a space (0x20). Note that this also excludes tabs, newlines, carriage returns, etc. This means that all leading spaces MUST be preserved as part of the value and all trailing spaces are considered to be optional whitespace characters not part of the value. They MAY be excluded when propagating the header.
+The value is an opaque string containing up to 256 printable ASCII [RFC0020] characters (i.e., the range 0x20 to 0x7E) except comma (,) and (=) which must end with a character which is not a space (0x20). Note that this also excludes tabs, newlines, carriage returns, etc. This means that all leading spaces MUST be preserved as part of the value and all trailing spaces are considered to be optional whitespace characters not part of the value. Optional whitespace MAY be excluded when propagating the header.
 
 ``` abnf
 value    = 0*255(chr) nblk-chr

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -282,7 +282,7 @@ A `key` MUST begin with a lowercase letter or a digit and contain up to 256 char
 
 ##### Value
 
-The value is an opaque string containing up to 256 printable ASCII [[!RFC0020]] characters (i.e., the range 0x20 to 0x7E) except comma (`,`) and (`=`). Note that this also excludes tabs, newlines, carriage returns, etc.
+The value is an opaque string containing up to 256 printable ASCII [RFC0020] characters (i.e., the range 0x20 to 0x7E) except comma (,) and (=) which must end with a character which is not a space (0x20). Note that this also excludes tabs, newlines, carriage returns, etc. This effectively means that all leading spaces MUST be preserved as part of the value and all trailing spaces MUST not be preserved.
 
 ``` abnf
 value    = 0*255(chr) nblk-chr

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -282,7 +282,7 @@ A `key` MUST begin with a lowercase letter or a digit and contain up to 256 char
 
 ##### Value
 
-The value is an opaque string containing up to 256 printable ASCII [[!RFC0020]] characters (i.e., the range 0x20 to 0x7E) except comma (,) and (=) which must end with a character which is not a space (0x20). Note that this also excludes tabs, newlines, carriage returns, etc. This means that all leading spaces MUST be preserved as part of the value and all trailing spaces are considered to be optional whitespace characters not part of the value. Optional whitespace MAY be excluded when propagating the header.
+The value is an opaque string containing up to 256 printable ASCII [[!RFC0020]] characters (i.e., the range 0x20 to 0x7E) except comma (,) and (=). The string must end with a character which is not a space (0x20). Note that this also excludes tabs, newlines, carriage returns, etc. All leading spaces MUST be preserved as part of the value. All trailing spaces are considered to be optional whitespace characters not part of the value. Optional trailing whitespace MAY be excluded when propagating the header.
 
 ``` abnf
 value    = 0*255(chr) nblk-chr


### PR DESCRIPTION
Currently the description does not reflect that a non-space character is mandatory. It is also helpful to clarify the handling of leading and trailing spaces as it is not so intuitive.

Fixes #409


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/anuraaga/trace-context/pull/411.html" title="Last updated on Jun 4, 2020, 4:17 AM UTC (1962f80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/411/32d0d82...anuraaga:1962f80.html" title="Last updated on Jun 4, 2020, 4:17 AM UTC (1962f80)">Diff</a>