### PR TITLE
fixing ABNF, related to #364

### DIFF
--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -258,8 +258,7 @@ A simple example of a `list` with two `list-member`s might look like:
 
 ``` abnf
 list  = list-member 0*31( OWS "," OWS list-member )
-list-member =  key "=" value
-list-member =/ OWS
+list-member = (key "=" value) / OWS
 ```
 
 Identifiers for a `list` are short (up to 256 characters) textual identifiers.

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -258,8 +258,8 @@ A simple example of a `list` with two `list-member`s might look like:
 
 ``` abnf
 list  = list-member 0*31( OWS "," OWS list-member )
-list-member = key "=" value
-list-member = OWS
+list-member =  key "=" value
+list-member =/ OWS
 ```
 
 Identifiers for a `list` are short (up to 256 characters) textual identifiers.


### PR DESCRIPTION
Addresses syntax problem of #364, but not the part:

> There's also a problem that the ABNF does not allow whitespace around
> "=", but the prose does.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/pull/432.html" title="Last updated on Nov 3, 2020, 11:58 PM UTC (7132c80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/432/6d95bd9...7132c80.html" title="Last updated on Nov 3, 2020, 11:58 PM UTC (7132c80)">Diff</a>