### PR TITLE
Replace all-upper case CAN with MAY

### DIFF
--- a/spec/10-overview.md
+++ b/spec/10-overview.md
@@ -33,6 +33,6 @@ Trace context is split into two individual propagation fields supporting interop
 Tracing tools can provide two levels of compliant behavior interacting with trace context:
 
 - At a minimum they MUST propagate the `traceparent` and `tracestate` headers and guarantee traces are not broken. This behavior is also referred to as forwarding a trace.
-- In addition they CAN also choose to participate in a trace by modifying the `traceparent` header and relevant parts of the `tracestate` header containing their proprietary information. This is also referred to as participating in a trace.
+- In addition they MAY also choose to participate in a trace by modifying the `traceparent` header and relevant parts of the `tracestate` header containing their proprietary information. This is also referred to as participating in a trace.
 
 A tracing tool can choose to change this behavior for each individual request to a component it is monitoring.


### PR DESCRIPTION
[BCP 14](https://tools.ietf.org/html/bcp14),
[RFC2119](https://tools.ietf.org/html/rfc2119) as well as
[RFC8174](https://tools.ietf.org/html/rfc8174) never mention CAN.

Using it in all upper-case indicates a defined normative meaning when
in fact that normative meaning is only defined for "MUST", "MUST NOT",
"REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
"RECOMMENDED",  "MAY", and "OPTIONAL".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/instana/trace-context/pull/435.html" title="Last updated on Oct 28, 2020, 6:17 AM UTC (83710db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/435/6d95bd9...instana:83710db.html" title="Last updated on Oct 28, 2020, 6:17 AM UTC (83710db)">Diff</a>