### PR TITLE
When the 32-entry limit is met, the right-most entry is removed

### DIFF
--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -310,7 +310,7 @@ Vendors SHOULD propagate at least 512 characters of a combined header. This leng
 
 There are systems where propagating of 512 characters of `tracestate` may be expensive. In this case, the maximum size of the propagated `tracestate` header SHOULD be documented and explained. The cost of propagating `tracestate` SHOULD be weighted against the value of monitoring scenarios enabled for the end users.
 
-In a situation where `tracestate` needs to be truncated due to size limitations, the vendor MUST truncate whole entries. Entries larger than `128` characters long SHOULD be removed first. Then entries SHOULD be removed starting from the end of `tracestate`. Note that other truncation strategies like safe list entries, blocked list entries, or size-based truncation MAY be used, but are highly discouraged. Those strategies decrease the interoperability of various tracing vendors.
+In a situation where `tracestate` is truncated due to the total size of the header value, the vendor MUST truncate whole entries. Entries larger than `128` characters long SHOULD be removed first. Then entries SHOULD be removed starting from the end of `tracestate`. Other truncation strategies like safe list entries, blocked list entries, or size-based truncation SHOULD NOT be used.
 
 ### Examples of tracestate HTTP Headers
 

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -247,7 +247,7 @@ The `OWS` rule defines an optional whitespace character. To improve readability,
 
 The caller SHOULD generate the optional whitespace as a single space; otherwise, a caller SHOULD NOT generate optional whitespace. See details in the <a data-cite='!RFC7230#whitespace'>corresponding RFC</a>.
 
-The `tracestate` field value is a `list` of `list-members` separated by commas (`,`). A `list-member` is a key/value pair separated by an equals sign (`=`). Spaces and horizontal tabs surrounding `list-member`s are ignored. There can be a maximum of 32 `list-member`s in a `list`.
+The `tracestate` field value is a `list` of `list-members` separated by commas (`,`). A `list-member` is a key/value pair separated by an equals sign (`=`). Spaces and horizontal tabs surrounding `list-member`s are ignored. There can be a maximum of 32 `list-member`s in a `list`. If adding an entry would cause the `tracestate` list to contain more than 32 `list-members` the right-most `list-member` should be removed from the list.
 
 Empty and whitespace-only list members are allowed. Vendors MUST accept empty `tracestate` headers but SHOULD avoid sending them. Empty list members are allowed in `tracestate` because it is difficult for a vendor to recognize the empty value when multiple `tracestate` headers are sent. Whitespace characters are allowed for a similar reason, as some vendors automatically inject whitespace after a comma separator, even in the case of an empty header.
 


### PR DESCRIPTION
Fixes #440 

/cc @MrAlias


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dynatrace-oss-contrib/trace-context/pull/448.html" title="Last updated on Jan 12, 2021, 9:12 PM UTC (05a18c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/448/56c7111...dynatrace-oss-contrib:05a18c3.html" title="Last updated on Jan 12, 2021, 9:12 PM UTC (05a18c3)">Diff</a>