### PR TITLE
Updated tracestate to specify that it should not be used for application level properties

### DIFF
--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -227,6 +227,8 @@ The main purpose of the `tracestate` HTTP header is to provide additional vendor
 
 If the vendor failed to parse `traceparent`, it MUST NOT attempt to parse `tracestate`. Note that the opposite is not true: failure to parse `tracestate` MUST NOT affect the parsing of `traceparent`.
 
+The `tracestate` HTTP header MUST NOT be used for _application_ level properties such as userId. [W3C baggage](https://github.com/w3c/baggage) provides the specification for defining and propagating application level properties.
+
 ### Header Name
 
 Header name: `tracestate`

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -227,7 +227,7 @@ The main purpose of the `tracestate` HTTP header is to provide additional vendor
 
 If the vendor failed to parse `traceparent`, it MUST NOT attempt to parse `tracestate`. Note that the opposite is not true: failure to parse `tracestate` MUST NOT affect the parsing of `traceparent`.
 
-The `tracestate` HTTP header MUST NOT be used for any properties that are not defined by a tracing vendor. [[BAGGAGE]] MAY be used for defining and propagating such application level properties.
+The `tracestate` HTTP header MUST NOT be used for any properties that are not defined by a telemetry system. [[BAGGAGE]] MAY be used for defining and propagating such application level properties.
 
 ### Header Name
 

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -227,7 +227,7 @@ The main purpose of the `tracestate` HTTP header is to provide additional vendor
 
 If the vendor failed to parse `traceparent`, it MUST NOT attempt to parse `tracestate`. Note that the opposite is not true: failure to parse `tracestate` MUST NOT affect the parsing of `traceparent`.
 
-The `tracestate` HTTP header MUST NOT be used for _application_ level properties such as userId. [[BAGGAGE]] MAY be used for defining and propagating application level properties.
+The `tracestate` HTTP header MUST NOT be used for any properties that are not defined by a tracing vendor. [[BAGGAGE]] MAY be used for defining and propagating such application level properties.
 
 ### Header Name
 

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -227,7 +227,7 @@ The main purpose of the `tracestate` HTTP header is to provide additional vendor
 
 If the vendor failed to parse `traceparent`, it MUST NOT attempt to parse `tracestate`. Note that the opposite is not true: failure to parse `tracestate` MUST NOT affect the parsing of `traceparent`.
 
-The `tracestate` HTTP header MUST NOT be used for any properties that are not defined by a telemetry system. [[BAGGAGE]] MAY be used for defining and propagating such application level properties.
+The `tracestate` HTTP header MUST NOT be used for any properties that are not defined by a tracing system. [[BAGGAGE]] MAY be used for defining and propagating such application level properties.
 
 ### Header Name
 

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -227,7 +227,7 @@ The main purpose of the `tracestate` HTTP header is to provide additional vendor
 
 If the vendor failed to parse `traceparent`, it MUST NOT attempt to parse `tracestate`. Note that the opposite is not true: failure to parse `tracestate` MUST NOT affect the parsing of `traceparent`.
 
-The `tracestate` HTTP header MUST NOT be used for _application_ level properties such as userId. [W3C baggage](https://github.com/w3c/baggage) provides the specification for defining and propagating application level properties.
+The `tracestate` HTTP header MUST NOT be used for _application_ level properties such as userId. [[BAGGAGE]] MAY be used for defining and propagating application level properties.
 
 ### Header Name
 


### PR DESCRIPTION
Updated tracestate section to specify that it should not be used for application level properties. Resolves #439.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kalyanaj/trace-context/pull/458.html" title="Last updated on Aug 31, 2021, 7:23 PM UTC (f647fb3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/458/0d32b21...kalyanaj:f647fb3.html" title="Last updated on Aug 31, 2021, 7:23 PM UTC (f647fb3)">Diff</a>