### PR TITLE
Move Daniel Khan to former editors

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,11 +18,6 @@
         w3cid: "103966"
       },
       {
-        name: "Daniel Khan",
-        company: "Dynatrace",
-        w3cid: "90530"
-      },
-      {
         name: "Daniel Dyla",
         company: "Dynatrace",
         w3cid: "117848"
@@ -56,6 +51,12 @@
         company: "Google",
         companyURL: "https://google.com",
         w3cid: "104091"
+      },
+      {
+        name: "Daniel Khan",
+        company: "Dynatrace",
+        companyURL: "https://dynatrace.com",
+        w3cid: "90530"
       }],
 
       github: {

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
       {
         name: "Daniel Dyla",
         company: "Dynatrace",
+        companyURL: "https://dynatrace.com",
         w3cid: "117848"
       },
       {


### PR DESCRIPTION
Now that Daniel is no longer in https://www.w3.org/groups/wg/distributed-tracing/participants he should be moved to the former editors section. Thank you Daniel for all your hard work!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dynatrace-oss-contrib/trace-context/pull/462.html" title="Last updated on Aug 4, 2021, 1:50 PM UTC (c2e5426)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/462/0d32b21...dynatrace-oss-contrib:c2e5426.html" title="Last updated on Aug 4, 2021, 1:50 PM UTC (c2e5426)">Diff</a>