### PR TITLE
fix(#459): remove confusing vendor/tenant wording

### DIFF
--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -280,8 +280,7 @@ lcalpha    = %x61-7A ; a-z
 
 **Note**: Identifiers MUST begin with a lowercase letter or a digit, and can only contain lowercase letters (`a`-`z`), digits (`0`-`9`), underscores (`_`), dashes (`-`), asterisks (`*`), and forward slashes (`/`).
 
-For multi-tenant vendor scenarios, an at sign (`@`) can be used to prefix the vendor name. Vendors SHOULD set the tenant ID at the beginning of the key. For example, \
-`fw529a3039@dt` - `fw529a3039` is a tenant ID and `@dt` is a vendor name. Searching for `@dt=` is more robust for parsing (for example, searching for all a vendor's keys).
+In a distributed application where different components may be traced by different instances of the same multi-tenant tracing system, the system SHOULD keep the system ID at the end of the key. For example, `001@xyz` where `001` is the ID of the specific tenant within the tracing system and `xyz` is the tracing system identifier. This makes for fast and robust parsing. For example, by searching for all instances of `@xyz=` a tracing system can easily find all keys made by system `xyz`.
 
 ##### Value
 

--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -270,17 +270,22 @@ A `list-member` contains a key/value pair.
 
 ##### Key
 
-The key is an identifier that describes the vendor.
+The key identifies the tracestate entry.
 
 ``` abnf
-key = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
-key = ( lcalpha / DIGIT ) 0*240( lcalpha / DIGIT / "_" / "-"/ "*" / "/" ) "@" lcalpha 0*13( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
+key = simple-key / multi-tenant-key
+simple-key = lcalpha 0*255( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
+multi-tenant-key = tenant-id "@" system-id
+tenant-id = ( lcalpha / DIGIT ) 0*240( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
+system-id = lcalpha 0*13( lcalpha / DIGIT / "_" / "-"/ "*" / "/" )
 lcalpha    = %x61-7A ; a-z
 ```
 
 **Note**: Identifiers MUST begin with a lowercase letter or a digit, and can only contain lowercase letters (`a`-`z`), digits (`0`-`9`), underscores (`_`), dashes (`-`), asterisks (`*`), and forward slashes (`/`).
 
-In a distributed application where different components may be traced by different instances of the same multi-tenant tracing system, the system SHOULD keep the system ID at the end of the key. For example, `001@xyz` where `001` is the ID of the specific tenant within the tracing system and `xyz` is the tracing system identifier. This makes for fast and robust parsing. For example, by searching for all instances of `@xyz=` a tracing system can easily find all keys made by system `xyz`.
+There are two different types of tracestate keys. The first type of key is a simple key used by tracing systems which do not have multiple tenants. Simple keys contain only lowercase alphanumeric characters, underscores, dashes, asterisks, and forward slashes. For example: `my-tracing-system`.
+
+The second type of key is used by multi-tenant tracing systems where each tenant requires a unique tracestate entry. Multi-tenant keys consist of a tenant ID followed by the `@` character followed by a system ID. This allows for fast and robust parsing. For example, tracing system `xyz` can easily find all of its tracestate entries by searching for all instances of `@xyz=`.
 
 ##### Value
 


### PR DESCRIPTION
This fixes #459 by making the prose underneath the ABNF in the key section more clear.

It is not required to fix this in `main` as the entire paragraph has been removed there.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dynatrace-oss-contrib/trace-context/pull/465.html" title="Last updated on Sep 24, 2021, 2:53 PM UTC (eea5d04)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/465/92cee7d...dynatrace-oss-contrib:eea5d04.html" title="Last updated on Sep 24, 2021, 2:53 PM UTC (eea5d04)">Diff</a>