### PR TITLE
Remove assertion that asserts a tracestate should not be created when empty

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -502,7 +502,6 @@ class TraceContextTest(TestBase):
 			['traceparent', '00-12345678901234567890123456789012-1234567890123456-00'],
 			['tracestate', ''],
 		])
-		self.assertTrue(not tracestate)
 		self.assertEqual(traceparent.trace_id.hex(), '12345678901234567890123456789012')
 
 		traceparent, tracestate = self.make_single_request_and_get_tracecontext([

--- a/test/test.py
+++ b/test/test.py
@@ -883,14 +883,14 @@ if __name__ == '__main__':
 Usage: python {0} <service endpoint> [patterns]
 
 Environment Variables:
-	HARNESS_DEBUG	  when set, debug mode will be enabled (default to disabled)
-	HARNESS_HOST	   the public host/address of the test harness (default 127.0.0.1)
-	HARNESS_PORT	   the public port of the test harness (default 7777)
-	HARNESS_TIMEOUT	the timeout (in seconds) used for each test case (default 5)
+	HARNESS_DEBUG      when set, debug mode will be enabled (default to disabled)
+	HARNESS_HOST       the public host/address of the test harness (default 127.0.0.1)
+	HARNESS_PORT       the public port of the test harness (default 7777)
+	HARNESS_TIMEOUT    the timeout (in seconds) used for each test case (default 5)
 	HARNESS_BIND_HOST  the host/address which the test harness binds to (default to HARNESS_HOST)
 	HARNESS_BIND_PORT  the port which the test harness binds to (default to HARNESS_PORT)
 	SERVICE_ENDPOINT   your test service endpoint (no default value)
-	STRICT_LEVEL	   the level of test strictness (default 2)
+	STRICT_LEVEL       the level of test strictness (default 2)
 
 Example:
 	python {0} http://127.0.0.1:5000/test

--- a/test/test.py
+++ b/test/test.py
@@ -502,6 +502,7 @@ class TraceContextTest(TestBase):
 			['traceparent', '00-12345678901234567890123456789012-1234567890123456-00'],
 			['tracestate', ''],
 		])
+		self.assertTrue(not tracestate or tracestate != '')
 		self.assertEqual(traceparent.trace_id.hex(), '12345678901234567890123456789012')
 
 		traceparent, tracestate = self.make_single_request_and_get_tracecontext([
@@ -882,14 +883,14 @@ if __name__ == '__main__':
 Usage: python {0} <service endpoint> [patterns]
 
 Environment Variables:
-	HARNESS_DEBUG      when set, debug mode will be enabled (default to disabled)
-	HARNESS_HOST       the public host/address of the test harness (default 127.0.0.1)
-	HARNESS_PORT       the public port of the test harness (default 7777)
-	HARNESS_TIMEOUT    the timeout (in seconds) used for each test case (default 5)
+	HARNESS_DEBUG	  when set, debug mode will be enabled (default to disabled)
+	HARNESS_HOST	   the public host/address of the test harness (default 127.0.0.1)
+	HARNESS_PORT	   the public port of the test harness (default 7777)
+	HARNESS_TIMEOUT	the timeout (in seconds) used for each test case (default 5)
 	HARNESS_BIND_HOST  the host/address which the test harness binds to (default to HARNESS_HOST)
 	HARNESS_BIND_PORT  the port which the test harness binds to (default to HARNESS_PORT)
 	SERVICE_ENDPOINT   your test service endpoint (no default value)
-	STRICT_LEVEL       the level of test strictness (default 2)
+	STRICT_LEVEL	   the level of test strictness (default 2)
 
 Example:
 	python {0} http://127.0.0.1:5000/test


### PR DESCRIPTION
I opened this based on my issue/question in #470.  I'm pretty confident this was an oversight.  I work on the Node.js agent team at New Relic and if I fix our agent to account for this use case it breaks a lot of our uses cases for passing context to downstream services.  

Closes #470 