### PR TITLE
ReSpec fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,9 +69,8 @@
       level: 2,
       format: "markdown",
       subjectPrefix: "trace-context",
-      wg: "Distributed Tracing Working Group",
+      group: "distributed-tracing",
       wgPublicList: "public-trace-context",
-      wgURI: "https://www.w3.org/2018/distributed-tracing/",
       otherLinks: [{
         key: 'Discussions',
         data: [{
@@ -85,8 +84,7 @@
               href: "https://en.wikipedia.org/wiki/Bit_field",
               publisher: "Wikipedia"
             }
-      },
-      wgPatentURI: "https://www.w3.org/2004/01/pp-impl/108594/status"
+      }
     };
   </script>
 </head>


### PR DESCRIPTION
Fix the following ReSpec error:

> Configuration options <code>wg</code>, <code>wgURI</code>, <code>wgId</code>, <code>wgPatentURI</code>, and <code>wgPatentPolicy</code> are deprecated. Please use the <a href="https://respec.org/docs/#group"><code>group</code></a> configuration option instead. <small>(Plugin: "w3c/group")</small>.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/pull/472.html" title="Last updated on Oct 22, 2021, 3:33 AM UTC (06c4ca5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/472/ce72c11...06c4ca5.html" title="Last updated on Oct 22, 2021, 3:33 AM UTC (06c4ca5)">Diff</a>