### PR TITLE
Update branch references from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build
-Status](https://img.shields.io/travis/w3c/trace-context/master.svg?label=validation%20service)](https://travis-ci.com/w3c/trace-context/)
+Status](https://img.shields.io/travis/w3c/trace-context/main.svg?label=validation%20service)](https://travis-ci.com/w3c/trace-context/)
 
 # Trace Context Specification
 
@@ -11,7 +11,7 @@ which specifies a distributed tracing context propagation format.
 
 The next version of specification is being developed in this repository.
 
-The current draft of the Trace Context Specification from this repository's master branch is published to  https://w3c.github.io/trace-context/.
+The current draft of the Trace Context Specification from this repository's main branch is published to  https://w3c.github.io/trace-context/.
 Explanations and justification for decisions made in this specification are written down in the [Rationale document](http_header_format_rationale.md).
 
 ## Team Communication

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
 
       github: {
         repoURL: "https://github.com/w3c/trace-context/",
-        branch: "master",
+        branch: "main",
       },
       edDraftURI: "https://w3c.github.io/trace-context/",
       shortName: "trace-context",

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://img.shields.io/travis/w3c/trace-context/master.svg?label=self%20test)](https://travis-ci.org/w3c/trace-context)
+[![Build Status](https://img.shields.io/travis/w3c/trace-context/main.svg?label=self%20test)](https://travis-ci.org/w3c/trace-context)
 
 # W3C Distributed Tracing Validation Service
 


### PR DESCRIPTION
The master branch was renamed to main in #454, but some references to the master branch were not updated.
This commit updates those locations to refer to the main branch instead of master.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/philsttr/trace-context/pull/473.html" title="Last updated on Oct 26, 2021, 12:40 AM UTC (523a538)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/473/ce72c11...philsttr:523a538.html" title="Last updated on Oct 26, 2021, 12:40 AM UTC (523a538)">Diff</a>