### PR TITLE
Specify expected behaviour when no traceparent is received

### DIFF
--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -334,6 +334,8 @@ The version of `tracestate` is defined by the version prefix of `traceparent` he
 
 ## Mutating the traceparent Field
 
+A vendor receiving a request without a `traceparent` header SHOULD generate `traceparent` headers for outbound requests, effectively starting a new trace. A possible reason to not add `traceparent` to outbound requests is when the vendor decides to not sample this request.
+
 A vendor receiving a `traceparent` request header MUST send it to outgoing requests. It MAY mutate the value of this header before passing it to outgoing requests.
 
 If the value of the `traceparent` field wasn't changed before propagation, `tracestate` MUST NOT be modified as well. Unmodified header propagation is typically implemented in pass-through services like proxies. This behavior may also be implemented in a service which currently does not collect distributed tracing information.

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -334,7 +334,7 @@ The version of `tracestate` is defined by the version prefix of `traceparent` he
 
 ## Mutating the traceparent Field
 
-A vendor receiving a request without a `traceparent` header SHOULD generate `traceparent` headers for outbound requests, effectively starting a new trace. A possible reason to not add `traceparent` to outbound requests is when the vendor decides to not sample this request.
+A vendor receiving a request without a `traceparent` header SHOULD generate `traceparent` headers for outbound requests, effectively starting a new trace. A possible reason for not doing this could be a performance sensitive scenario when the vendor decides to not sample a request. Note that for most scenarios, vendors are expected to generate the header even when not sampling, to propagate the sampling decision downstream.
 
 A vendor receiving a `traceparent` request header MUST send it to outgoing requests. It MAY mutate the value of this header before passing it to outgoing requests.
 


### PR DESCRIPTION
Resolves #442.

As discussed in the previous working group meeting, this PR adds a clarification around the expected behaviour when no traceparent headers is received.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/instana/trace-context/pull/475.html" title="Last updated on Dec 8, 2021, 8:19 AM UTC (3e68405)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/475/3081b03...instana:3e68405.html" title="Last updated on Dec 8, 2021, 8:19 AM UTC (3e68405)">Diff</a>