### PR TITLE
add required "on" trigger to Github action "self-test"

### DIFF
--- a/.github/workflows/self_test.yml
+++ b/.github/workflows/self_test.yml
@@ -1,3 +1,17 @@
+name: Self Test
+on:
+  push:
+    branches:
+    - main
+    paths:
+      - 'test/**.py'
+      - 'test/**.json'
+  pull_request:
+    branches:
+    - main
+    paths:
+      - 'test/**.py'
+      - 'test/**.json'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/self_test.yml
+++ b/.github/workflows/self_test.yml
@@ -1,17 +1,15 @@
 name: Self Test
 on:
   push:
-    branches:
-    - main
     paths:
       - 'test/**.py'
       - 'test/**.json'
+      - '.github/workflows/self_test.yml'
   pull_request:
-    branches:
-    - main
     paths:
       - 'test/**.py'
       - 'test/**.json'
+      - '.github/workflows/self_test.yml'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,7 +22,5 @@ jobs:
           python-version: 3.6
           architecture: x64
       - run: pip install aiohttp
-      - run: |
-          cd test
-          python self_test.py
+      - run: cd test && python self_test.py
         shell: bash


### PR DESCRIPTION
A few pull requests I created seemed to have triggered the Github action
(self_test.yml) which then failed with

```
Error : .github#L1
No event triggers defined in `on`
```

This seems to be the case since the initial commit for adding Github
actions:
https://github.com/w3c/trace-context/actions/runs/937108242

Apparently .github/workflows/self_test.yml is simply invalid.

I added some triggers as I see fit. Let's see what Octocat thinks of
this.