### PR TITLE
must->should for keys mutation fix up

### DIFF
--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -355,7 +355,7 @@ Vendors MUST NOT make any other mutations to the `traceparent` header.
 
 ## Mutating the tracestate Field
 
-Vendors receiving a `tracestate` request header MUST send it to outgoing requests. It MAY mutate the value of this header before passing to outgoing requests. When mutating `tracestate`, the order of unmodified key/value pairs MUST be preserved. Modified keys MUST be moved to the beginning (left) of the list.
+Vendors receiving a `tracestate` request header MUST send it to outgoing requests. It MAY mutate the value of this header before passing to outgoing requests. When mutating `tracestate`, the order of unmodified key/value pairs MUST be preserved. Modified keys SHOULD be moved to the beginning (left) of the list.
 
 Following are allowed mutations:
 


### PR DESCRIPTION
In response to this comment: https://github.com/w3c/trace-context/issues/469#issuecomment-967578222


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/pull/479.html" title="Last updated on Nov 16, 2021, 5:41 AM UTC (60bf6c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/479/859f549...60bf6c6.html" title="Last updated on Nov 16, 2021, 5:41 AM UTC (60bf6c6)">Diff</a>