### PR TITLE
An alternative proposal on implementing randomness by updating level …

### DIFF
--- a/spec/20-http_header_format.md
+++ b/spec/20-http_header_format.md
@@ -100,13 +100,17 @@ trace-flags      = 2HEXDIGLC   ; 8 bit flags. Currently, only one bit is used. S
 
 #### trace-id
 
-This is the ID of the whole trace forest and is used to uniquely identify a <a href="#dfn-distributed-traces">distributed trace</a> through a system. It is represented as a 16-byte array, for example, `4bf92f3577b34da6a3ce929d0e0e4736`. All bytes as zero (`00000000000000000000000000000000`) is considered an invalid value.
+This is the ID that is used to uniquely identify a <a href="#dfn-distributed-traces">distributed trace</a> through a system. It is represented as a 16-byte array, for example, `4bf92f3577b34da6a3ce929d0e0e4736`.
 
-If the `trace-id` value is invalid (for example if it contains non-allowed characters or all zeros), vendors MUST ignore the `traceparent`.
+For the interoperability between vendors, the 6 right most bytes of `trace-id` SHOULD be generated using random or pseudo-random number generation algorithm. If [[!RFC4122]] is used, only the <a data-cite='!RFC4122##section-4.4'>Algorithms for Creating a UUID from Truly Random or Pseudo-Random Numbers</a> can be used for `trace-id` value generation to satisfy the randomness requirement.
 
 See [considerations for trace-id field
 generation](#considerations-for-trace-id-field-generation) for recommendations
 on how to operate with `trace-id`.
+
+All bytes as zero (`00000000000000000000000000000000`) is considered an invalid value.
+
+If the `trace-id` value is invalid (for example if it contains non-allowed characters or all zeros), vendors MUST ignore the `traceparent`.
 
 #### parent-id
 

--- a/spec/60-trace-id-format.md
+++ b/spec/60-trace-id-format.md
@@ -6,7 +6,7 @@ practices will ensure better interoperability of different systems.
 
 ### Uniqueness of `trace-id`
 
-The value of `trace-id` SHOULD be globally unique. This field is typically used
+The value of `trace-id` SHOULD be globally unique. This field is used
 for unique identification of a <a>distributed trace</a>. It is common for
 <a>distributed traces</a> to span various components, including, for example,
 cloud services. Cloud services tend to serve variety of clients and have a very
@@ -15,16 +15,19 @@ even when local uniqueness might seem like a good solution.
 
 ### Randomness of `trace-id`
 
-Randomly generated value of `trace-id` SHOULD be preferred over other
-algorithms of generating a globally unique identifiers. Randomness of `trace-id`
-addresses some [security](#security-considerations) and [privacy
-concerns](#privacy-considerations) of exposing unwanted information. Randomness
-also allows tracing vendors to base sampling decisions on `trace-id` field value
-and avoid propagating an additional sampling context.
+For the interoperability between vendors, `trace-id` value SHOULD contain
+random bytes. With other considerations, random bytes SHOULD be the right most
+characters and at least 6 right most bytes (12 characters) SHOULD be generated
+using random or pseudo-random number generation algorithm.
 
-As shown in the next section, it is important for `trace-id` to carry
-"uniqueness" and "randomness" in the right part of the `trace-id`, for better
-inter-operability with some existing systems.
+Randomness of `trace-id` addresses some [security](#security-considerations)
+and [privacy concerns](#privacy-considerations) of exposing unwanted
+information. Randomness also allows tracing vendors to base various sharding
+and sampling decisions on `trace-id` field value and avoid propagating an
+additional sampling context.
+
+When [[!RFC4122]] is used for `trace-id` value generation, the required 12
+right most characters are generated as random or pseudo-random. Whenever possible fully randomly generated value of `trace-id` SHOULD be preferred.
 
 ### Handling `trace-id` for compliant platforms with shorter internal identifiers
 


### PR DESCRIPTION
…1 spec

I wanted to draft this to propose it as an alternative to the https://github.com/w3c/trace-context/pull/474. As discussed before, spec already had all suggestions to generate randomness and keep it as right most characters. Clarification to the already existing language and keeping it as `SHOULD` makes it compatible to the existing version. Also, most of implementations are already setting random bytes and will be compatible.

I'd suggest we review and consider this as an alternative to the flag-based proposal. It eliminates the fragmentation of implementations. All OpenTelemetry implementations will work fine out of the box.

As for the issue of implementations that do not generate randomness (on purpose or due to an error), this proposal may be cleaner as it eliminates situations when the flag is set and implementation is still not providing randomness.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/pull/480.html" title="Last updated on Nov 16, 2021, 7:48 AM UTC (ee4be7b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/480/859f549...ee4be7b.html" title="Last updated on Nov 16, 2021, 7:48 AM UTC (ee4be7b)">Diff</a>