### PR TITLE
Remove incorrect randomness claim from privacy considerations

### DIFF
--- a/spec/50-privacy.md
+++ b/spec/50-privacy.md
@@ -6,7 +6,7 @@ Vendors MUST assess the risk of header abuse. This section provides some conside
 
 ## Privacy of traceparent field
 
-The `traceparent` field MUST NOT contain any personally identifiable information. One way to achieve this is to randomly generate all trace IDs. If a random number generator leverages any user identifiable information like IP address as seed state, this information may be exposed. Random number generators MUST NOT rely on any information that can potentially be user-identifiable.
+The `traceparent` field MUST NOT contain any personally identifiable information. One way to achieve this is to randomly generate all trace IDs using a random number generator that does not expose any personally identifiable information. Any random number generator used for generating trace IDs MUST NOT rely on any information as input or seed state that can potentially be personally identifiable.
 
 Another privacy risk of the `traceparent` field is the ability to correlate requests made as part of a single transaction. A downstream service may track and correlate two or more requests made in a single transaction and may make assumptions about the identity of the caller of a request based on information from another request.
 

--- a/spec/50-privacy.md
+++ b/spec/50-privacy.md
@@ -6,7 +6,7 @@ Vendors MUST assess the risk of header abuse. This section provides some conside
 
 ## Privacy of traceparent field
 
-The `traceparent` field is comprised of randomly-generated numbers. If a random number generator leverages any user identifiable information like IP address as seed state, this information may be exposed. Random number generators MUST NOT rely on any information that can potentially be user-identifiable.
+The `traceparent` field MUST NOT contain any personally identifiable information. One way to achieve this is to randomly generate all trace IDs. If a random number generator leverages any user identifiable information like IP address as seed state, this information may be exposed. Random number generators MUST NOT rely on any information that can potentially be user-identifiable.
 
 Another privacy risk of the `traceparent` field is the ability to correlate requests made as part of a single transaction. A downstream service may track and correlate two or more requests made in a single transaction and may make assumptions about the identity of the caller of a request based on information from another request.
 

--- a/spec/60-trace-id-format.md
+++ b/spec/60-trace-id-format.md
@@ -22,9 +22,9 @@ concerns](#privacy-considerations) of exposing unwanted information. Randomness
 also allows tracing vendors to base sampling decisions on `trace-id` field value
 and avoid propagating an additional sampling context.
 
-As shown in the next section, it is important for `trace-id` to carry
-"uniqueness" and "randomness" in the right part of the `trace-id`, for better
-inter-operability with some existing systems.
+As shown in the next section, if part of the `trace-id` is nonrandom,
+it is important for the random part of the `trace-id` to be as far right in the
+`trace-id` as possible for better inter-operability with some existing systems.
 
 ### Handling `trace-id` for compliant platforms with shorter internal identifiers
 


### PR DESCRIPTION
Related to #481 

Fix the contradiction in `main`, this fix will need to be backported to `level-1` before #481 is closed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dynatrace-oss-contrib/trace-context/pull/482.html" title="Last updated on Jan 5, 2022, 4:12 PM UTC (9c76e0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/482/3081b03...dynatrace-oss-contrib:9c76e0d.html" title="Last updated on Jan 5, 2022, 4:12 PM UTC (9c76e0d)">Diff</a>