### PR TITLE
Fix typo in "however"

### DIFF
--- a/spec/60-trace-id-format.md
+++ b/spec/60-trace-id-format.md
@@ -40,7 +40,7 @@ the system is encouraged to utilize the `tracestate` header to propagate the
 additional internal identifier. However, if a system would instead prefer to use
 the internal identifier as the basis for a fully compliant `trace-id`, it SHOULD
 be incorporated at the as rightmost part of a `trace-id`. For example, tracing
-system may receive `234a5bcd543ef3fa53ce929d0e0e4736` as a `trace-id`, hovewer
+system may receive `234a5bcd543ef3fa53ce929d0e0e4736` as a `trace-id`, however
 internally it will use `53ce929d0e0e4736` as an identifier.
 
 ### Interoperating with existing systems which use shorter identifiers


### PR DESCRIPTION
Hi, there is a small typo in `60-trace-id-format.md`.

As far as I understand there is no need for any patent/license assignment since this is a non-significant change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mwalser/trace-context/pull/490.html" title="Last updated on Jun 20, 2022, 3:12 PM UTC (45b6745)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/490/4aee100...mwalser:45b6745.html" title="Last updated on Jun 20, 2022, 3:12 PM UTC (45b6745)">Diff</a>