### PR TITLE
Resolves #487: Update wording on "response headers" in privacy section to disambiguate from traceresponse headers.

### DIFF
--- a/spec/50-privacy.md
+++ b/spec/50-privacy.md
@@ -24,4 +24,4 @@ Vendors extremely sensitive to personal information exposure MAY implement selec
 
 ## Other risks
 
-When vendors include `traceparent` and `tracestate` headers in responses, these values may inadvertently be passed to cross-origin callers. Vendors should ensure that they include only these response headers when responding to systems that participated in the trace.
+When vendors include `traceparent` and `tracestate` headers in responses, these values may inadvertently be passed to cross-origin callers. Hence, if vendors include this information in responses, they should ensure that they do so only when responding to systems that participated in the trace.

--- a/spec/50-privacy.md
+++ b/spec/50-privacy.md
@@ -24,4 +24,4 @@ Vendors extremely sensitive to personal information exposure MAY implement selec
 
 ## Other risks
 
-When vendors include `traceparent` and `tracestate` headers in responses, these values may inadvertently be passed to cross-origin callers. Hence, if vendors include this information in responses, they should ensure that they do so only when responding to systems that participated in the trace.
+When vendors include `traceparent` and `tracestate` headers in responses, these values may inadvertently be passed to cross-origin callers. Hence, if vendors include this information in responses, they should be aware that it could be seen by systems that did not participate in the trace.

--- a/spec/50-privacy.md
+++ b/spec/50-privacy.md
@@ -24,4 +24,4 @@ Vendors extremely sensitive to personal information exposure MAY implement selec
 
 ## Other risks
 
-When vendors include `traceparent` and `tracestate` headers in responses, these values may inadvertently be passed to cross-origin callers. Hence, if vendors include this information in responses, they should be aware that it could be seen by systems that did not participate in the trace.
+When vendors include values from the `traceparent` and `tracestate` headers in responses, these values may inadvertently be passed to cross-origin callers. Hence, if vendors include this information in responses, they should be aware that it could be seen by systems that did not participate in the trace.


### PR DESCRIPTION
Resolves #487


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kalyanaj/trace-context/pull/491.html" title="Last updated on Sep 27, 2022, 11:32 PM UTC (a079992)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/491/84b583d...kalyanaj:a079992.html" title="Last updated on Sep 27, 2022, 11:32 PM UTC (a079992)">Diff</a>