### PR TITLE
Add test case for random flag propagation

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -79,12 +79,30 @@ Content-Type: application/json
 		HARNESS_BIND_HOST  the host/address which the test harness binds to (default to HARNESS_HOST)
 		HARNESS_BIND_PORT  the port which the test harness binds to (default to HARNESS_PORT)
 		SERVICE_ENDPOINT   your test service endpoint (no default value)
+		STRICT_LEVEL       the level of test strictness (default 2)
+		SPEC_LEVEL         the minimum version of the Trace Context specification being tested (default 2)
 
 	Example:
+		# Run all tests
 		python test.py http://127.0.0.1:5000/test
+		# Run one test
 		python test.py http://127.0.0.1:5000/test TraceContextTest.test_both_traceparent_and_tracestate_missing
+		# Run one test suite
 		python test.py http://127.0.0.1:5000/test AdvancedTest
+		# Run two test suites
+		python test.py http://127.0.0.1:5000/test AdvancedTest TraceContext2Test
+		# Combinations of the above
 		python test.py http://127.0.0.1:5000/test AdvancedTest TraceContextTest.test_both_traceparent_and_tracestate_missing
+		python test.py http://127.0.0.1:5000/test AdvancedTest TraceContextTest.test_both_traceparent_and_tracestate_missing TraceContext2Test.test_propagates_random_flag
+		python test.py http://127.0.0.1:5000/test AdvancedTest TraceContext2Test TraceContextTest.test_both_traceparent_and_tracestate_missing
+
+	Available Test Suites:
+		TraceContextTest
+			Trace Context Level 1 support
+		AdvancedTest
+			Advanced Trace Context Level 1 support
+		TraceContext2Test
+			Trace Context Level 2 support
 	```
 * Alternatively, you can use the Python [unit testing framework](https://docs.python.org/3/library/unittest.html) module to run the test.
 	```

--- a/test/test.py
+++ b/test/test.py
@@ -13,13 +13,16 @@ server = None
 def environ(name, default = None):
 	if not name in os.environ:
 		if default:
-			os.environ[name] = default
+			return default
 		else:
 			raise EnvironmentError('environment variable {} is not defined'.format(name))
 	return os.environ[name]
 
-STRICT_LEVEL = int(environ('STRICT_LEVEL', '2'))
-SPEC_LEVEL = int(environ('SPEC_LEVEL', '2'))
+DEFAULT_SPEC_LEVEL = '1'
+DEFAULT_STRICT_LEVEL = '2'
+
+STRICT_LEVEL = int(environ('STRICT_LEVEL', DEFAULT_STRICT_LEVEL))
+SPEC_LEVEL = int(environ('SPEC_LEVEL', DEFAULT_SPEC_LEVEL))
 print('STRICT_LEVEL: {}'.format(STRICT_LEVEL))
 print('SPEC_LEVEL:   {}'.format(SPEC_LEVEL))
 
@@ -917,7 +920,7 @@ Environment Variables:
 	HARNESS_BIND_PORT  the port which the test harness binds to (default to HARNESS_PORT)
 	SERVICE_ENDPOINT   your test service endpoint (no default value)
 	STRICT_LEVEL       the level of test strictness (default 2)
-	SPEC_LEVEL         the minimum version of the Trace Context specification being tested (default 2)
+	SPEC_LEVEL         the minimum version of the Trace Context specification being tested (default 1)
 
 Example:
 	# Run all tests
@@ -942,6 +945,9 @@ Available Test Suites:
 		Trace Context Level 2 support
 		'''.strip().format(sys.argv[0]), file = sys.stderr)
 		exit(-1)
+
+	if not 'SPEC_LEVEL' in os.environ:
+		print('Warning: The environment variable SPEC_LEVEL has not been set. Defaulting to specification level %s. Consider setting SPEC_LEVEL explicitly if your implementation is based on a different specification level. In the future, the default specification level of this test suite may be raised.' % (DEFAULT_SPEC_LEVEL))
 
 	host = environ('HARNESS_HOST', '127.0.0.1')
 	port = environ('HARNESS_PORT', '7777')

--- a/test/test.py
+++ b/test/test.py
@@ -911,10 +911,26 @@ Environment Variables:
 	SPEC_LEVEL         the minimum version of the Trace Context specification being tested (default 2)
 
 Example:
+	# Run all tests
 	python {0} http://127.0.0.1:5000/test
+	# Run one test
 	python {0} http://127.0.0.1:5000/test TraceContextTest.test_both_traceparent_and_tracestate_missing
+	# Run one test suite
 	python {0} http://127.0.0.1:5000/test AdvancedTest
+	# Run two test suites
+	python {0} http://127.0.0.1:5000/test AdvancedTest TraceContext2Test
+	# Combinations of the above
 	python {0} http://127.0.0.1:5000/test AdvancedTest TraceContextTest.test_both_traceparent_and_tracestate_missing
+	python {0} http://127.0.0.1:5000/test AdvancedTest TraceContextTest.test_both_traceparent_and_tracestate_missing TraceContext2Test.test_propagates_random_flag
+	python {0} http://127.0.0.1:5000/test AdvancedTest TraceContext2Test TraceContextTest.test_both_traceparent_and_tracestate_missing
+
+Available Test Suites:
+	TraceContextTest
+		Trace Context Level 1 support
+	AdvancedTest
+		Advanced Trace Context Level 1 support
+	TraceContext2Test
+		Trace Context Level 2 support
 		'''.strip().format(sys.argv[0]), file = sys.stderr)
 		exit(-1)
 

--- a/test/test.py
+++ b/test/test.py
@@ -114,6 +114,15 @@ class TestBase(unittest.TestCase):
 		headers = self.make_request(headers)[0]['headers']
 		return (self.get_traceparent(headers), self.get_tracestate(headers))
 
+	def assert_bit_set(self, value, n, message = None):
+		'''
+		assert that the nth position bit of value is set where n == 0 is the least significant bit
+		'''
+		msg = "expected value 0x{:02x} to have #{}th bit set but it did not".format(value, n)
+		if message:
+			msg += " : " + message
+		self.assertEqual(value & (1 << n - 1), (1 << n - 1), msg)
+
 class TraceContextTest(TestBase):
 	def test_both_traceparent_and_tracestate_missing(self):
 		'''
@@ -890,7 +899,7 @@ class TraceContext2Test(TestBase):
 		])
 		self.assertEqual(traceparent.trace_id.hex(), '12345678901234567890123456789012')
 		self.assertNotEqual(traceparent.parent_id.hex(), '1234567890123456')
-		self.assertTrue(traceparent.trace_flags & (1 << 1) == (1 << 1))
+		self.assert_bit_set(traceparent.trace_flags, 2, "random flag not set")
 
 if __name__ == '__main__':
 	if len(sys.argv) >= 2:

--- a/test/tracecontext/tracestate.py
+++ b/test/tracecontext/tracestate.py
@@ -70,7 +70,7 @@ class Tracestate(object):
 	# if the tracestate value size is bigger than 512 characters, the tracer
 	# CAN decide to forward the tracestate
 	def is_valid(self):
-		if len(self) is 0:
+		if len(self) == 0:
 			return False
 		# combined header length MUST be less than or equal to 512 bytes
 		if len(self.to_string()) > 512:


### PR DESCRIPTION
This adds a test case which asserts that the random flag is propagated. It only runs if the newly added SPEC_LEVEL variable is 2 or greater (default 2).