### PR TITLE
Updated the flags description in version format

### DIFF
--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -95,7 +95,7 @@ The following `version-format` definition is used for version `00`.
 version-format   = trace-id "-" parent-id "-" trace-flags
 trace-id         = 32HEXDIGLC  ; 16 bytes array identifier. All zeroes forbidden
 parent-id        = 16HEXDIGLC  ; 8 bytes array identifier. All zeroes forbidden
-trace-flags      = 2HEXDIGLC   ; 8 bit flags. Currently, only one bit is used. See below for details
+trace-flags      = 2HEXDIGLC   ; 8 bit flags. Currently, only two bits are used. See below for details.
 ```
 
 #### trace-id

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -95,7 +95,7 @@ The following `version-format` definition is used for version `00`.
 version-format   = trace-id "-" parent-id "-" trace-flags
 trace-id         = 32HEXDIGLC  ; 16 bytes array identifier. All zeroes forbidden
 parent-id        = 16HEXDIGLC  ; 8 bytes array identifier. All zeroes forbidden
-trace-flags      = 2HEXDIGLC   ; 8 bit flags. Currently, only two bits are used. See below for details.
+trace-flags      = 2HEXDIGLC   ; 8 bit flags.
 ```
 
 #### trace-id
@@ -120,9 +120,7 @@ Vendors MUST ignore the `traceparent` when the `parent-id` is invalid (for examp
 
 #### trace-flags
 
-The current version of this specification (`00`) supports only two flags: `sampled` and `random-trace-id`.
-
-An <a data-cite='!BIT-FIELD#firstHeading'>8-bit field</a>  that controls tracing flags such as sampling, trace level, etc. These flags are recommendations given by the caller rather than strict rules to follow for three reasons:
+This is an <a data-cite='!BIT-FIELD#firstHeading'>8-bit field</a> that controls tracing flags such as sampling, trace level, etc. These flags are recommendations given by the caller rather than strict rules to follow for three reasons:
 
 1. An untrusted caller may be able to abuse a tracing system by setting these flags maliciously.
 2. A caller may have a bug which causes the tracing system to have a problem.


### PR DESCRIPTION
Updated flags description in version format to specify the right number of bits used in the flags.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kalyanaj/trace-context/pull/505.html" title="Last updated on Oct 13, 2022, 9:32 PM UTC (35a7f80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/505/fb068ff...kalyanaj:35a7f80.html" title="Last updated on Oct 13, 2022, 9:32 PM UTC (35a7f80)">Diff</a>