### PR TITLE
improve description of version field in traceresponse header 

### DIFF
--- a/spec/21-http_response_header_format.md
+++ b/spec/21-http_response_header_format.md
@@ -34,12 +34,10 @@ The dash (`-`) character is used as a delimiter between fields.
 #### version
 
 ``` abnf
-version         = 2HEXDIGLC   ; this document assumes version 00. Version 255 is forbidden
+version         = 2HEXDIGLC   ; this document assumes version 00. Version ff is forbidden
 ```
 
-The value is US-ASCII encoded (which is UTF-8 compliant).
-
-Version (`version`) is 1 byte representing an 8-bit unsigned integer. Version `255` is invalid. The current specification assumes the `version` is set to `00`.
+Version (`version`) is an 8-bit unsigned integer value, serialized as an ASCII string with two characters. Version 255 (`"ff"`) is invalid. This specification assumes the version is set to 0 (`"00"`).
 
 #### version-format
 

--- a/spec/21-http_response_header_format.md
+++ b/spec/21-http_response_header_format.md
@@ -37,7 +37,7 @@ The dash (`-`) character is used as a delimiter between fields.
 version         = 2HEXDIGLC   ; this document assumes version 00. Version ff is forbidden
 ```
 
-Version (`version`) is an 8-bit unsigned integer value, serialized as an ASCII string with two characters. Version 255 (`"ff"`) is invalid. This specification assumes the version is set to 0 (`"00"`).
+Version (`version`) is an 8-bit unsigned integer value, serialized as an ASCII string with two characters. Version 255 (`"ff"`) is invalid. This document specifies version 0 (`"00"`) of the `traceresponse` header.
 
 #### version-format
 


### PR DESCRIPTION
This fixes the confusing wording in the description of the version field, which previously didn't clearly distinguish between a possible internal representation (1 byte) and the format on the wire (two ascii chars).

This change ports the new description of the version field in the request header over to the response header and aligns both descriptions. See https://github.com/w3c/trace-context/pull/511.

In contrast to #511, this will not be backported to level 2 (level 2 does not have the response header).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/instana/trace-context/pull/512.html" title="Last updated on Dec 7, 2022, 7:29 AM UTC (ad4d9d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/512/f9d9e05...instana:ad4d9d0.html" title="Last updated on Dec 7, 2022, 7:29 AM UTC (ad4d9d0)">Diff</a>