### PR TITLE
improve wording for casing of request header names

### DIFF
--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -62,9 +62,9 @@ The `traceparent` HTTP header field identifies the incoming request in a tracing
 
 Header name: `traceparent`
 
-In order to increase interoperability across multiple protocols and encourage successful integration, by default vendors SHOULD keep the header name lowercase. The header name is a single word without any delimiters, for example, a hyphen (`-`).
+The header name is [ASCII case-insensitive](https://infra.spec.whatwg.org/#ascii-case-insensitive). That is, `TRACEPARENT`, `TraceParent`, and `traceparent` are considered the same header. The header name is a single word, it does not contain any delimiters such as a hyphen.
 
-Vendors MUST expect the header name in any case (upper, lower, mixed), and SHOULD send the header name in lowercase.
+In order to increase interoperability across multiple protocols and encourage successful integration, tracing systems SHOULD encode the header name as [ASCII lowercase](https://infra.spec.whatwg.org/#ascii-lowercase).
 
 ### traceparent Header Field Values
 
@@ -252,9 +252,9 @@ The `tracestate` HTTP header MUST NOT be used for any properties that are not de
 
 Header name: `tracestate`
 
-In order to increase interoperability across multiple protocols and encourage successful integration, by default you SHOULD keep the header name lowercase. The header name is a single word without any delimiters, for example, a hyphen (`-`).
+The header name is [ASCII case-insensitive](https://infra.spec.whatwg.org/#ascii-case-insensitive). That is, `TRACESTATE`, `TraceState`, and `tracestate` are considered the same header. The header name is a single word, it does not contain any delimiters such as a hyphen.
 
-Vendors MUST expect the header name in any case (upper, lower, mixed), and SHOULD send the header name in lowercase.
+In order to increase interoperability across multiple protocols and encourage successful integration, tracing systems SHOULD encode the header name as [ASCII lowercase](https://infra.spec.whatwg.org/#ascii-lowercase).
 
 ### tracestate Header Field Values
 

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -62,7 +62,7 @@ The `traceparent` HTTP header field identifies the incoming request in a tracing
 
 Header name: `traceparent`
 
-The header name is [ASCII case-insensitive](https://infra.spec.whatwg.org/#ascii-case-insensitive). That is, `TRACEPARENT`, `TraceParent`, and `traceparent` are considered the same header. The header name is a single word, it does not contain any delimiters such as a hyphen.
+The header name is [ASCII case-insensitive](https://infra.spec.whatwg.org/#ascii-case-insensitive). That is, `TRACEPARENT`, `TraceParent`, and `traceparent` are considered the same header. The header name is a single word; it does not contain any delimiters such as a hyphen.
 
 In order to increase interoperability across multiple protocols and encourage successful integration, tracing systems SHOULD encode the header name as [ASCII lowercase](https://infra.spec.whatwg.org/#ascii-lowercase).
 


### PR DESCRIPTION
fixes #506

Needs to be backported to `level-2`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/instana/trace-context/pull/513.html" title="Last updated on Dec 7, 2022, 6:12 AM UTC (b5fcd5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/513/f9d9e05...instana:b5fcd5c.html" title="Last updated on Dec 7, 2022, 6:12 AM UTC (b5fcd5c)">Diff</a>