### PR TITLE
updates the versions used in the Github action to run the tests

### DIFF
--- a/.github/workflows/self_test.yml
+++ b/.github/workflows/self_test.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Run the python tests
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.6
+          python-version: 3.11.2
           architecture: x64
       - run: pip install aiohttp
       - run: cd test && python self_test.py


### PR DESCRIPTION
This should fix the error observed in the [latest run](https://github.com/w3c/trace-context/actions/runs/4281420808/jobs/7454424092#step:3:8) of the Github action:

```
Run actions/setup-python@v2
  with:
    python-version: [3](https://github.com/w3c/trace-context/actions/runs/4281420808/jobs/7454424092#step:3:3).6
    architecture: x6[4](https://github.com/w3c/trace-context/actions/runs/4281420808/jobs/7454424092#step:3:4)
    token: ***
Version 3.[6](https://github.com/w3c/trace-context/actions/runs/4281420808/jobs/7454424092#step:3:7) was not found in the local cache
Error: Version 3.6 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

Looks better now: https://github.com/w3c/trace-context/actions/runs/4281612498/jobs/7454847299