### PR TITLE
Updated the flags description in version format

### DIFF
--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -93,7 +93,7 @@ The following `version-format` definition is used for version `00`.
 version-format   = trace-id "-" parent-id "-" trace-flags
 trace-id         = 32HEXDIGLC  ; 16 bytes array identifier. All zeroes forbidden
 parent-id        = 16HEXDIGLC  ; 8 bytes array identifier. All zeroes forbidden
-trace-flags      = 2HEXDIGLC   ; 8 bit flags. Currently, only one bit is used. See below for details
+trace-flags      = 2HEXDIGLC   ; 8 bit flags.
 ```
 
 #### trace-id
@@ -118,9 +118,7 @@ Vendors MUST ignore the `traceparent` when the `parent-id` is invalid (for examp
 
 #### trace-flags
 
-The current version of this specification (`00`) supports only two flags: `sampled` and `random-trace-id`.
-
-An <a data-cite='!BIT-FIELD#firstHeading'>8-bit field</a>  that controls tracing flags such as sampling, trace level, etc. These flags are recommendations given by the caller rather than strict rules to follow for three reasons:
+This is an <a data-cite='!BIT-FIELD#firstHeading'>8-bit field</a> that controls tracing flags such as sampling, trace level, etc. These flags are recommendations given by the caller rather than strict rules to follow for three reasons:
 
 1. An untrusted caller may be able to abuse a tracing system by setting these flags maliciously.
 2. A caller may have a bug which causes the tracing system to have a problem.


### PR DESCRIPTION
Updated flags description in version format to specify the right number of bits used in the flags.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/instana/trace-context/pull/535.html" title="Last updated on May 9, 2023, 7:30 PM UTC (238eecd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/535/387f9b1...instana:238eecd.html" title="Last updated on May 9, 2023, 7:30 PM UTC (238eecd)">Diff</a>