### PR TITLE
make wording around duplicate tracestate headers more precise

### DIFF
--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -318,7 +318,7 @@ The `tracestate` value is the concatenation of trace graph key/value pairs.
 
 Example: `vendorname1=opaqueValue1,vendorname2=opaqueValue2`
 
-Only one entry per key is allowed. For example, if a vendor name is Congo and a trace started in their system and then went through a system named Rojo and later returned to Congo, the `tracestate` value would not be:
+Tracing tools are not supposed to add the same header multiple times. For example, if a vendor name is Congo and a trace started in their system and then went through a system named Rojo and later returned to Congo, the `tracestate` value would not be:
 
 `congo=congosFirstPosition,rojo=rojosFirstPosition,congo=congosSecondPosition`
 


### PR DESCRIPTION
Participants must not add duplicated tracestate keys, but they are not responsible for cleaning up duplicated tracestate keys that another updstream participant has added.

fixes #548


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/instana/trace-context/pull/552.html" title="Last updated on Nov 14, 2023, 8:15 PM UTC (7946bf2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/552/7eff747...instana:7946bf2.html" title="Last updated on Nov 14, 2023, 8:15 PM UTC (7946bf2)">Diff</a>