### PR TITLE
explict rules for traceresponse/random-trace-id when continuing a trace

### DIFF
--- a/spec/21-http_response_header_format.md
+++ b/spec/21-http_response_header_format.md
@@ -107,7 +107,7 @@ When a participant starts or restarts a trace (that is, when the participant gen
 
 A participant that continues a trace started upstream &mdash; that is, if the participant uses the `trace-id` value from an incoming `traceparent` header in its own `traceresponse` header &mdash; MUST set the `random-trace-id` flag in the `traceresponse` header to the same value that was found in the incoming `traceparent` header.
 
-A participant that continues a trace started downstream &mdash; that is, if the participant uses the `trace-id` value from a `traceresponse` header it has receieved &mdash; MUST set the `random-trace-id` flag in its own `traceresponse` header to the same value that was found in the `traceresponse` header from which the `trace-id` was taken.
+A participant that continues a trace started downstream &mdash; that is, if the participant uses the `trace-id` value from a `traceresponse` header it has received &mdash; MUST set the `random-trace-id` flag in its own `traceresponse` header to the same value that was found in the `traceresponse` header from which the `trace-id` was taken.
 
 ##### Other Flags
 

--- a/spec/21-http_response_header_format.md
+++ b/spec/21-http_response_header_format.md
@@ -53,7 +53,7 @@ trace-flags      = 2HEXDIGLC   ; 8 bit flags. See below for details
 
 The format and requirements for this are the same as those of the trace-id field in the `traceparent` request header.
 
-For details, see the trace-id section under [traceparent Header Field Values](#traceparent-Header-Field-Values).
+For details, see the trace-id section under [traceparent Header Field Values](#traceparent-header-field-values).
 
 #### child-id
 
@@ -105,7 +105,7 @@ the specification for this flag.
 
 The format and requirements for this are the same as those of the random-trace-id flag in the trace-flags field in the `traceparent` request header.
 
-For details, see the trace-flags section under [traceparent Header Field Values](#traceparent-Header-Field-Values).
+For details, see the trace-flags section under [traceparent Header Field Values](#traceparent-header-field-values).
 
 
 ##### Other Flags

--- a/spec/21-http_response_header_format.md
+++ b/spec/21-http_response_header_format.md
@@ -103,10 +103,11 @@ The second least significant bit of the trace-flags field denotes the random-tra
 If a trace was started by a downstream participant and it responds with the `traceresponse` HTTP header, an upstream participant can use this flag to determine if the `trace-id` was generated as per
 the specification for this flag.
 
-The format and requirements for this are the same as those of the random-trace-id flag in the trace-flags field in the `traceparent` request header.
+When a participant starts or restarts a trace (that is, when the participant generates a new `trace-id`), the requirements for this flag are the same as those for the random-trace-id flag in the trace-flags field in the `traceparent` request header. For details, see the section [Random Trace ID Flag](#random-trace-id-flag).
 
-For details, see the trace-flags section under [traceparent Header Field Values](#traceparent-header-field-values).
+A participant that continues a trace started upstream &mdash; that is, if the participant uses the `trace-id` value from an incoming `traceparent` header in its own `traceresponse` header &mdash; MUST set the `random-trace-id` flag in the `traceresponse` header to the same value that was found in the incoming `traceparent` header.
 
+A participant that continues a trace started downstream &mdash; that is, if the participant uses the `trace-id` value from a `traceresponse` header it has receieved &mdash; MUST set the `random-trace-id` flag in its own `traceresponse` header to the same value that was found in the `traceresponse` header from which the `trace-id` was taken.
 
 ##### Other Flags
 

--- a/spec/21-http_response_header_format.md
+++ b/spec/21-http_response_header_format.md
@@ -63,7 +63,7 @@ Vendors MUST ignore the `traceresponse` header when the `child-id` is invalid (f
 
 #### trace-flags
 
-Similar to the `trace-flags` field in the `traceparent` request header, this is a hex-encoded <a data-cite='!BIT-FIELD#firstHeading'>8-bit field</a> that provides information about how a callee handled the trace. The same requirement to properly mask the bit field value when interpreting it applies here as well.
+Similar to the [`trace-flags` field](#trace-flags) in the `traceparent` request header, this is a hex-encoded <a data-cite='!BIT-FIELD#firstHeading'>8-bit field</a> that provides information about how a callee handled the trace. The same requirement to properly mask the bit field value when interpreting it applies here as well.
 
 The current version of this specification (`00`) supports only two flags: `sampled` and `random-trace-id`.
 


### PR DESCRIPTION
Fixes https://github.com/w3c/trace-context/issues/540.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/instana/trace-context/pull/555.html" title="Last updated on Dec 12, 2023, 7:52 PM UTC (5c7f3f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/555/2178be0...instana:5c7f3f5.html" title="Last updated on Dec 12, 2023, 7:52 PM UTC (5c7f3f5)">Diff</a>