### PR TITLE
fix: ensure random part of trace id is uniformly distributed

### DIFF
--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -185,7 +185,7 @@ There are two additional options that vendors MAY follow:
 The second least significant bit of the trace-flags field denotes the `random-trace-id` flag.
 
 When starting or restarting a trace (that is, when the participant generates a new `trace-id`), the following rules apply:
-* If that flag is set, at least the right-most 7 bytes of the `trace-id` MUST be random (or pseudo-random).
+* If that flag is set, at least the right-most 7 bytes of the `trace-id` MUST be selected randomly (or pseudo-randomly) from a uniform distribution of all `2^56` possible values.
 * If the flag is not set, the `trace-id` MAY still be randomly (or pseudo-randomly) generated.
 * When unset, the `trace-id` MAY be generated in any way that satisfies the requirements of the [trace ID format](#trace-id).
 * When at least the right-most 7 bytes of the `trace-id` are randomly (or pseudo-randomly) generated, the `random-trace-id` flag SHOULD be set to `1`.

--- a/spec/20-http_request_header_format.md
+++ b/spec/20-http_request_header_format.md
@@ -185,7 +185,7 @@ There are two additional options that vendors MAY follow:
 The second least significant bit of the trace-flags field denotes the `random-trace-id` flag.
 
 When starting or restarting a trace (that is, when the participant generates a new `trace-id`), the following rules apply:
-* If that flag is set, at least the right-most 7 bytes of the `trace-id` MUST be selected randomly (or pseudo-randomly) from a uniform distribution of all `2^56` possible values.
+* If that flag is set, at least the right-most 7 bytes of the `trace-id` MUST be selected randomly (or pseudo-randomly) with uniform distribution over the interval [0..2^56-1].
 * If the flag is not set, the `trace-id` MAY still be randomly (or pseudo-randomly) generated.
 * When unset, the `trace-id` MAY be generated in any way that satisfies the requirements of the [trace ID format](#trace-id).
 * When at least the right-most 7 bytes of the `trace-id` are randomly (or pseudo-randomly) generated, the `random-trace-id` flag SHOULD be set to `1`.

--- a/spec/60-trace-id-format.md
+++ b/spec/60-trace-id-format.md
@@ -23,8 +23,8 @@ also allows tracing vendors to base sampling decisions on `trace-id` field value
 and avoid propagating an additional sampling context.
 
 If the `random-trace-id` flag is set, at least the right-most 7 bytes of the
-`trace-id` MUST be selected randomly (or pseudo-randomly) from a uniform
-distribution of all `2^56` possible values.
+`trace-id` MUST be selected randomly (or pseudo-randomly) with uniform distribution
+over the interval [0..2^56-1].
 
 As shown in the next section, if part of the `trace-id` is nonrandom,
 it is important for the random part of the `trace-id` to be as far right in the

--- a/spec/60-trace-id-format.md
+++ b/spec/60-trace-id-format.md
@@ -23,7 +23,8 @@ also allows tracing vendors to base sampling decisions on `trace-id` field value
 and avoid propagating an additional sampling context.
 
 If the `random-trace-id` flag is set, at least the right-most 7 bytes of the
-`trace-id` MUST be randomly (or pseudo-randomly) generated.
+`trace-id` MUST be selected randomly (or pseudo-randomly) from a uniform
+distribution of all `2^56` possible values.
 
 As shown in the next section, if part of the `trace-id` is nonrandom,
 it is important for the random part of the `trace-id` to be as far right in the


### PR DESCRIPTION
Partially addresses #544


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 502 Bad Gateway :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 1, 2024, 9:04 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fdynatrace-oss-contrib%2Ftrace-context%2Fcd8ca6f6d66804abae0cb0c491e585ce32651079%2Findex.html%3FisPreview%3Dtrue)

```
error code: 502
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/trace-context%23558.)._
</details>
