### PR TITLE
Use server-timing for trace context response

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,8 @@
               href: "https://en.wikipedia.org/wiki/Bit_field",
               publisher: "Wikipedia"
             }
-      }
+      },
+      xref: ["server-timing"]
     };
   </script>
 </head>

--- a/spec/21-http_response_header_format.md
+++ b/spec/21-http_response_header_format.md
@@ -1,6 +1,6 @@
 # Trace Context Server Timing Metric Format
 
-This section describes the binding of the distributed trace context to a metric in the Server Timing HTTP header.
+This section describes the binding of the distributed trace context to a metric in the Server Timing HTTP response header.
 
 ## Trace Context Metric
 
@@ -42,9 +42,9 @@ The format and requirements for this are the same as those of the `trace-id` fie
 
 For details, see the `trace-id` section under [traceparent Header Field Values](#traceparent-header-field-values).
 
-#### child-id
+#### span-id
 
-This is the span ID of the server operation. It is represented as an 8-byte array, for example, `00f067aa0ba902b7`. An all-zero child ID (`0000000000000000`) is an invalid value. Tracing systems MUST ignore the trace context metric when the child id is invalid (for example, if it contains non-lowercase hex characters).
+This is the span ID of the server operation. It is represented as an 8-byte array, for example, `00f067aa0ba902b7`. An all-zero child ID (`0000000000000000`) is an invalid value. Tracing systems MUST ignore the trace context metric when the span id is invalid (for example, if it contains non-lowercase hex characters).
 
 For details, see the `span-id` section under [traceparent Header Field Values](#traceparent-header-field-values).
 


### PR DESCRIPTION
This is a first draft of the server-timing response header. It is not meant to be a final version, but a place to start discussion. It is mostly a direct translation with the following exceptions:

### Version is optional

In the original version, all fields were required in order to simplify parsing. Now that we are a small component of a more complex header, that simplicity is lost, and the parsing simplification is no longer beneficial.

### Flags are optional

The reasoning is the same as above. Additionally, some servers may not want to reveal information like the sampled flag to an untrusted client in order to avoid abuse.

### Terminology Fixes

Changed ambiguous or nonstandard terms like "callee" and "caller" to established terms like "server" and "client."


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dynatrace-oss-contrib/trace-context/pull/560.html" title="Last updated on Aug 25, 2025, 8:29 PM UTC (88ba098)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/trace-context/560/bc3c536...dynatrace-oss-contrib:88ba098.html" title="Last updated on Aug 25, 2025, 8:29 PM UTC (88ba098)">Diff</a>