### PR TITLE
Adds a pure javascript implementation of trace contexts

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -116,3 +116,12 @@ This page contains an alphabetical list of projects and vendors that currently i
 | [JavaScript](https://github.com/open-telemetry/opentelemetry-js/blob/a49e7abdab3e313ad2b50a9445a885b3fd0d4783/packages/opentelemetry-core/src/context/propagation/HttpTraceContext.ts) | [1](https://www.w3.org/TR/trace-context-1/) |
 | [Python](https://github.com/open-telemetry/opentelemetry-python/blob/dbb3be802bae8e4e5c36748869dbc789e50de217/opentelemetry-api/src/opentelemetry/trace/__init__.py) | [1](https://www.w3.org/TR/trace-context-1/) |
 | [Ruby](https://github.com/open-telemetry/opentelemetry-ruby/blob/741ca61a934b05ecbaedffa56a830dc1821ca9a1/api/lib/opentelemetry/distributed_context/propagation/trace_parent.rb) | [1](https://www.w3.org/TR/trace-context-1/) |
+
+## tctx
+
+**Website:** [github.com/maraisr/tctx](https://github.com/maraisr/tctx)
+
+**Implementations:**
+| Implementations | Specification Level |
+| --------------- | :-----------------: |
+| [JavaScript](https://github.com/maraisr/tctx) | [2](https://www.w3.org/TR/trace-context-2/) |


### PR DESCRIPTION
Ive built and published an NPM (and soon deno, jsr) library for dealing with trace contexts. Was originally built as a backing plane for my tracer [rian](https://github.com/maraisr/rian), but think this can be useful for many more people.

I am also running your test harness level 2:

[w3c validation test ✅](https://github.com/maraisr/tctx/actions/runs/8487542494/job/23255480687#step:13:101)

https://github.com/maraisr/tctx/blob/c4d62510034ae584a111389df878169fb30f249a/validation/test.sh#L16-L17

Im a mega fan of this spec, and love seeing where its going. 
